### PR TITLE
Overall improvements

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745875161,
-        "narHash": "sha256-0YkWCS13jpoo3+sX/3kcgdxBNt1VZTmvF+FhZb4rFKI=",
+        "lastModified": 1751702058,
+        "narHash": "sha256-/GTdqFzFw/Y9DSNAfzvzyCMlKjUyRKMPO+apIuaTU4A=",
         "owner": "tweag",
         "repo": "gomod2nix",
-        "rev": "2cbd7fdd6eeab65c494cc426e18f4e4d2a5e35c0",
+        "rev": "664ad7a2df4623037e315e4094346bff5c44e9ee",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749794982,
-        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
         "type": "github"
       },
       "original": {

--- a/justfile
+++ b/justfile
@@ -6,8 +6,9 @@ default:
   @just --list
 
 # Lint whole project
+[working-directory: "./server"]
 lint:
-    cd server && gofmt -s -w .
+    gofmt -s -w .
     # cd vs-code-extension && yarn run lint
 
 # Build config-lsp and test it in nvim (config-lsp will be loaded automatically)

--- a/server/common-documentation/mnt-cifs.go
+++ b/server/common-documentation/mnt-cifs.go
@@ -147,7 +147,7 @@ If the server requires signing during protocol negotiation, then it may be enabl
 	docvalues.CreateEnumStringWithDoc(
 		"rsize",
 		`default network read size (usually 16K). The client currently can not use rsize larger than CIFSMaxBufSize. CIFSMaxBufSize defaults to 16K and may be changed (from 8K to the maximum kmalloc size allowed by your kernel) at module install time for cifs.ko. Setting CIFSMaxBufSize to a very large value will cause cifs to use more memory and may reduce performance in some cases. To use rsize greater than 127K (the original cifs protocol maximum) also requires that the server support a new Unix Capability flag (for very large read) which some newer servers (e.g. Samba 3.0.26 or later) do. rsize can be set from a minimum of 2048 to a maximum of 130048 (127K or CIFSMaxBufSize, whichever is smaller)`,
-	): &docvalues.DataAmountValue{
+	): docvalues.DataAmountValue{
 		AllowedUnits: map[rune]struct{}{
 			'k': {},
 			'm': {},

--- a/server/common-documentation/mnt-cifs.go
+++ b/server/common-documentation/mnt-cifs.go
@@ -75,11 +75,11 @@ This is preferred over having passwords in plaintext in a shared file, such as /
 	docvalues.CreateEnumStringWithDoc(
 		"file_mode",
 		`If the server does not support the CIFS Unix extensions this overrides the default file mode.`,
-	): docvalues.StringValue{},
+	): docvalues.MaskModeValue{},
 	docvalues.CreateEnumStringWithDoc(
 		"dir_mode",
 		`If the server does not support the CIFS Unix extensions this overrides the default mode for directories.`,
-	): docvalues.StringValue{},
+	): docvalues.MaskModeValue{},
 	docvalues.CreateEnumStringWithDoc(
 		"ip",
 		`sets the destination IP address. This option is set automatically if the server name portion of the requested UNC name can be resolved so rarely needs to be specified by the user.`,
@@ -147,7 +147,16 @@ If the server requires signing during protocol negotiation, then it may be enabl
 	docvalues.CreateEnumStringWithDoc(
 		"rsize",
 		`default network read size (usually 16K). The client currently can not use rsize larger than CIFSMaxBufSize. CIFSMaxBufSize defaults to 16K and may be changed (from 8K to the maximum kmalloc size allowed by your kernel) at module install time for cifs.ko. Setting CIFSMaxBufSize to a very large value will cause cifs to use more memory and may reduce performance in some cases. To use rsize greater than 127K (the original cifs protocol maximum) also requires that the server support a new Unix Capability flag (for very large read) which some newer servers (e.g. Samba 3.0.26 or later) do. rsize can be set from a minimum of 2048 to a maximum of 130048 (127K or CIFSMaxBufSize, whichever is smaller)`,
-	): docvalues.StringValue{},
+	): &docvalues.DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+		},
+		AllowByteSuffix: false,
+		Base: docvalues.DataAmountValueBase1024,
+		AllowDecimal: false,
+		Validator: docvalues.CreateDARangeValidator("2048", "127K", docvalues.DataAmountValueBase1024),
+	},
 	docvalues.CreateEnumStringWithDoc(
 		"wsize",
 		`Maximum amount of data that the kernel will send in a write request in bytes. Prior to RHEL6.2 kernels, the default and maximum was 57344 (14 * 4096 pages). As of RHEL6.2, the default depends on whether the client and server negotiate large writes via POSIX extensions. If they do then the default is 1M, and the maximum allowed is 16M. If they do not, then the default is 65536 and the maximum allowed is 131007.

--- a/server/common-documentation/mnt-cifs.go
+++ b/server/common-documentation/mnt-cifs.go
@@ -1,0 +1,321 @@
+package commondocumentation
+
+import docvalues "config-lsp/doc-values"
+
+var CifsDocumentationAssignable = map[docvalues.EnumString]docvalues.DeprecatedValue{
+	docvalues.CreateEnumStringWithDoc(
+		"user",
+		`specifies the username to connect as. If this is not given, then the environment variable USER is used. This option can also take the form "user%password" or "workgroup/user" or "workgroup/user%password" to allow the password and workgroup to be specified as part of the username.
+Note
+The cifs vfs accepts the parameter user=, or for users familiar with smbfs it accepts the longer form of the parameter username=. Similarly the longer smbfs style parameter names may be accepted as synonyms for the shorter cifs parameters pass=,dom= and cred=.`,
+	): docvalues.UserValue("", false),
+	docvalues.CreateEnumStringWithDoc(
+		"password",
+		`specifies the CIFS password. If this option is not given then the environment variable PASSWD is used. If the password is not specified directly or indirectly via an argument to mount, mount.cifs will prompt for a password, unless the guest option is specified.`,
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"credentials",
+		`specifies a file that contains a username and/or password and optionally the name of the workgroup. The format of the file is:
+username=value
+
+password=value
+
+domain=value
+
+This is preferred over having passwords in plaintext in a shared file, such as /etc/fstab. Be sure to protect any credentials file properly.`,
+	): docvalues.PathValue{
+		RequiredType: docvalues.PathTypeFile,
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"uid",
+		`sets the uid that will own all files or directories on the mounted filesystem when the server does not provide ownership information. It may be specified as either a username or a numeric uid. When not specified, the default is uid 0. The mount.cifs helper must be at version 1.10 or higher to support specifying the uid in non-numeric form. See the section on FILE AND DIRECTORY OWNERSHIP AND PERMISSIONS below for more information.`,
+	): docvalues.OrValue{
+		Values: []docvalues.DeprecatedValue{
+			docvalues.UIDValue{
+				EnforceUsingExisting: false,
+			},
+			docvalues.UserValue("", false),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"cruid",
+		`sets the uid of the owner of the credentials cache. This is primarily useful with sec=krb5. The default is the real uid of the process performing the mount. Setting this parameter directs the upcall to look for a credentials cache owned by that user.`,
+	): docvalues.UIDValue{
+		EnforceUsingExisting: false,
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"gid",
+		`sets the gid that will own all files or directories on the mounted filesystem when the server does not provide ownership information. It may be specified as either a groupname or a numeric gid. When not specified, the default is gid 0. The mount.cifs helper must be at version 1.10 or higher to support specifying the gid in non-numeric form. See the section on FILE AND DIRECTORY OWNERSHIP AND PERMISSIONS below for more information.`,
+	): docvalues.OrValue{
+		Values: []docvalues.DeprecatedValue{
+			docvalues.GIDValue{
+				EnforceUsingExisting: false,
+			},
+			docvalues.GroupValue("", false),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"port",
+		`sets the port number on which the client will attempt to contact the CIFS server. If this value is specified, look for an existing connection with this port, and use that if one exists. If one doesn't exist, try to create a new connection on that port. If that connection fails, return an error. If this value isn't specified, look for an existing connection on port 445 or 139. If no such connection exists, try to connect on port 445 first and then port 139 if that fails. Return an error if both fail.`,
+	): docvalues.NumberRangeValue(1, 65535),
+	docvalues.CreateEnumStringWithDoc(
+		"servernetbiosname",
+		`Specify the server netbios name (RFC1001 name) to use when attempting to setup a session to the server. Although rarely needed for mounting to newer servers, this option is needed for mounting to some older servers (such as OS/2 or Windows 98 and Windows ME) since when connecting over port 139 they, unlike most newer servers, do not support a default server name. A server name can be up to 15 characters long and is usually uppercased.`,
+	// TODO: Add regex check for RFC1001 name
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"servern",
+		"Synonym for servernetbiosname.",
+	): docvalues.StringValue{},
+	// TODO: Show warning when port is not 193
+	docvalues.CreateEnumStringWithDoc(
+		"netbiosname",
+		`When mounting to servers via port 139, specifies the RFC1001 source name to use to represent the client netbios machine name when doing the RFC1001 netbios session initialize.`,
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"file_mode",
+		`If the server does not support the CIFS Unix extensions this overrides the default file mode.`,
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"dir_mode",
+		`If the server does not support the CIFS Unix extensions this overrides the default mode for directories.`,
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"ip",
+		`sets the destination IP address. This option is set automatically if the server name portion of the requested UNC name can be resolved so rarely needs to be specified by the user.`,
+	): docvalues.IPAddressValue{
+		AllowIPv4:  true,
+		AllowIPv6:  true,
+		AllowRange: false,
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"domain",
+		`sets the domain (workgroup) of the user`,
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"cache",
+		`Cache mode. See the section below on CACHE COHERENCY for details.
+The default in kernels prior to 3.7 was "loose". As of kernel 3.7 the default is "strict".`,
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("none", "do not cache file data at all"),
+			docvalues.CreateEnumStringWithDoc("strict", "follow the CIFS/SMB2 protocol strictly"),
+			docvalues.CreateEnumStringWithDoc("loose", "allow loose caching semantics"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"backupuid",
+		`Restrict access to files with the backup intent to a user. Either a name or an id must be provided as an argument, there are no default values.
+See section ACCESSING FILES WITH BACKUP INTENT for more details`,
+	): docvalues.OrValue{
+		Values: []docvalues.DeprecatedValue{
+			docvalues.UIDValue{
+				EnforceUsingExisting: false,
+			},
+			docvalues.UserValue("", false),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"backupgid",
+		`Restrict access to files with the backup intent to a group. Either a name or an id must be provided as an argument, there are no default values.
+See section ACCESSING FILES WITH BACKUP INTENT for more details`,
+	): docvalues.OrValue{
+		Values: []docvalues.DeprecatedValue{
+			docvalues.GIDValue{
+				EnforceUsingExisting: false,
+			},
+			docvalues.GroupValue("", false),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"sec",
+		`Security mode.
+If the server requires signing during protocol negotiation, then it may be enabled automatically. Packet signing may also be enabled automatically if it's enabled in /proc/fs/cifs/SecurityFlags.`,
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("none", "attempt to connection as a null user (no name)"),
+			docvalues.CreateEnumStringWithDoc("krb5", "Use Kerberos version 5 authentication"),
+			docvalues.CreateEnumStringWithDoc("krb5i", "Use Kerberos authentication and forcibly enable packet signing"),
+			docvalues.CreateEnumStringWithDoc("ntlm", "Use NTLM password hashing (default)"),
+			docvalues.CreateEnumStringWithDoc("ntlmi", "Use NTLM password hashing and force packet signing"),
+			docvalues.CreateEnumStringWithDoc("ntlmv2", "Use NTLMv2 password hashing"),
+			docvalues.CreateEnumStringWithDoc("ntlmv2i", "Use NTLMv2 password hashing and force packet signing"),
+			docvalues.CreateEnumStringWithDoc("ntlmssp", "Use NTLMv2 password hashing encapsulated in Raw NTLMSSP message"),
+			docvalues.CreateEnumStringWithDoc("ntlmsspi", "Use NTLMv2 password hashing encapsulated in Raw NTLMSSP message, and force packet signing"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"rsize",
+		`default network read size (usually 16K). The client currently can not use rsize larger than CIFSMaxBufSize. CIFSMaxBufSize defaults to 16K and may be changed (from 8K to the maximum kmalloc size allowed by your kernel) at module install time for cifs.ko. Setting CIFSMaxBufSize to a very large value will cause cifs to use more memory and may reduce performance in some cases. To use rsize greater than 127K (the original cifs protocol maximum) also requires that the server support a new Unix Capability flag (for very large read) which some newer servers (e.g. Samba 3.0.26 or later) do. rsize can be set from a minimum of 2048 to a maximum of 130048 (127K or CIFSMaxBufSize, whichever is smaller)`,
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"wsize",
+		`Maximum amount of data that the kernel will send in a write request in bytes. Prior to RHEL6.2 kernels, the default and maximum was 57344 (14 * 4096 pages). As of RHEL6.2, the default depends on whether the client and server negotiate large writes via POSIX extensions. If they do then the default is 1M, and the maximum allowed is 16M. If they do not, then the default is 65536 and the maximum allowed is 131007.
+Note that this value is just a starting point for negotiation. The client and server may negotiate this size downward according to the server's capabilities.`,
+	): docvalues.NumberRangeValue(1, 131007),
+	docvalues.CreateEnumStringWithDoc(
+		"actimeo",
+		`The time (in seconds) that the CIFS client caches attributes of a file or directory before it requests attribute information from a server. During this period the changes that occur on the server remain undetected until the client checks the server again.
+By default, the attribute cache timeout is set to 1 second. This means more frequent on-the-wire calls to the server to check whether attributes have changed which could impact performance. With this option users can make a tradeoff between performance and cache metadata correctness, depending on workload needs. Shorter timeouts mean better cache coherency, but frequent increased number of calls to the server. Longer timeouts mean a reduced number of calls to the server but looser cache coherency. The actimeo value is a positive integer that can hold values between 0 and a maximum value of 2^30 * HZ (frequency of timer interrupt) setting.`,
+	): docvalues.NumberRangeValue(0, 1073741823),
+	docvalues.CreateEnumStringWithDoc(
+		"prefixpath",
+		`It's possible to mount a subdirectory of a share. The preferred way to do this is to append the path to the UNC when mounting. However, it's also possible to do the same by setting this option and providing the path there.`,
+	): docvalues.PathValue{
+		RequiredType: docvalues.PathTypeDirectory,
+		IsOptional:   true,
+	},
+
+	// This option is listed as having no arg, but I'm pretty sure it does
+	docvalues.CreateEnumStringWithDoc(
+		"iocharset",
+		`Charset used to convert local path names to and from Unicode. Unicode is used by default for network path names if the server supports it. If iocharset is not specified then the nls_default specified during the local client kernel build will be used. If server does not support Unicode, this parameter is unused.`,
+	): docvalues.EnumValue{
+		EnforceValues: true,
+		Values:        AvailableCharsets,
+	},
+}
+
+var CifsDocumentationEnums = []docvalues.EnumString{
+	docvalues.CreateEnumStringWithDoc(
+		"forceuid",
+		`instructs the client to ignore any uid provided by the server for files and directories and to always assign the owner to be the value of the uid= option. See the section on FILE AND DIRECTORY OWNERSHIP AND PERMISSIONS below for more information.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"forcegid",
+		`instructs the client to ignore any gid provided by the server for files and directories and to always assign the owner to be the value of the gid= option. See the section on FILE AND DIRECTORY OWNERSHIP AND PERMISSIONS below for more information.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"guest",
+		`don't prompt for a password`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"ro",
+		`mount read-only`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"rw",
+		`mount read-write`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"setuids",
+		`If the CIFS Unix extensions are negotiated with the server the client will attempt to set the effective uid and gid of the local process on newly created files, directories, and devices (create, mkdir, mknod). If the CIFS Unix Extensions are not negotiated, for newly created files and directories instead of using the default uid and gid specified on the the mount, cache the new file's uid and gid locally which means that the uid for the file can change when the inode is reloaded (or the user remounts the share).`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"nosetuids",
+		`The client will not attempt to set the uid and gid on on newly created files, directories, and devices (create, mkdir, mknod) which will result in the server setting the uid and gid to the default (usually the server uid of the user who mounted the share). Letting the server (rather than the client) set the uid and gid is the default.If the CIFS Unix Extensions are not negotiated then the uid and gid for new files will appear to be the uid (gid) of the mounter or the uid (gid) parameter specified on the mount.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"perm",
+		`Client does permission checks (vfs_permission check of uid and gid of the file against the mode and desired operation), Note that this is in addition to the normal ACL check on the target machine done by the server software. Client permission checking is enabled by default.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"noperm",
+		`Client does not do permission checks. This can expose files on this mount to access by other users on the local client system. It is typically only needed when the server supports the CIFS Unix Extensions but the UIDs/GIDs on the client and server system do not match closely enough to allow access by the user doing the mount. Note that this does not affect the normal ACL check on the target machine done by the server software (of the server ACL against the user name provided at mount time).`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"dynperm",
+		`Instructs the server to maintain ownership and permissions in memory that can't be stored on the server. This information can disappear at any time (whenever the inode is flushed from the cache), so while this may help make some applications work, it's behavior is somewhat unreliable. See the section below on FILE AND DIRECTORY OWNERSHIP AND PERMISSIONS for more information.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"directio",
+		`Do not do inode data caching on files opened on this mount. This precludes mmaping files on this mount. In some cases with fast networks and little or no caching benefits on the client (e.g. when the application is doing large sequential reads bigger than page size without rereading the same data) this can provide better performance than the default behavior which caches reads (readahead) and writes (writebehind) through the local Linux client pagecache if oplock (caching token) is granted and held.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"strictcache",
+		`Use for switching on strict cache mode. In this mode the client reads from the cache all the time it has Oplock Level II, otherwise - read from the server. As for write - the client stores a data in the cache in Exclusive Oplock case, otherwise - write directly to the server.
+This option is will be deprecated in 3.7. Users should use cache=strict instead on more recent kernels.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"rwpidforward",
+		`Forward pid of a process who opened a file to any read or write operation on that file. This prevent applications like WINE from failing on read and write if we use mandatory brlock style.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"mapchars",
+		`Translate six of the seven reserved characters (not backslash, but including the colon, question mark, pipe, asterik, greater than and less than characters) to the remap range (above 0xF000), which also allows the CIFS client to recognize files created with such characters by Windows's POSIX emulation. This can also be useful when mounting to most versions of Samba (which also forbids creating and opening files whose names contain any of these seven characters). This has no effect if the server does not support Unicode on the wire. Please note that the files created with mapchars mount option may not be accessible if the share is mounted without that option.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"nomapchars",
+		`Do not translate any of these seven characters (default)`,
+	),
+	// TODO: Show a warning when this is used
+	docvalues.CreateEnumStringWithDoc(
+		"intr",
+		`currently unimplemented`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"nointr",
+		`(default) currently unimplemented`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"hard",
+		`The program accessing a file on the cifs mounted file system will hang when the server crashes.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"soft",
+		`(default) The program accessing a file on the cifs mounted file system will not hang when the server crashes and will return errors to the user application.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"noacl",
+		`Do not allow POSIX ACL operations even if server would support them.
+The CIFS client can get and set POSIX ACLs (getfacl, setfacl) to Samba servers version 3.0.10 and later. Setting POSIX ACLs requires enabling both CIFS_XATTR and then CIFS_POSIX support in the CIFS configuration options when building the cifs module. POSIX ACL support can be disabled on a per mount basis by specifying "noacl" on mount.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"cifsacl",
+		`This option is used to map CIFS/NTFS ACLs to/from Linux permission bits, map SIDs to/from UIDs and GIDs, and get and set Security Descriptors.
+See sections on CIFS/NTFS ACL, SID/UID/GID MAPPING, SECURITY DESCRIPTORS for more information.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"nocase",
+		`Request case insensitive path name matching (case sensitive is the default if the server suports it).`,
+	),
+	// TODO: Show grayed text when this is used
+	docvalues.CreateEnumStringWithDoc(
+		"ignorecase",
+		`Synonym for nocase.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"nobrl",
+		`Do not send byte range lock requests to the server. This is necessary for certain applications that break with cifs style mandatory byte range locks (and most cifs servers do not yet support requesting advisory byte range locks).`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"sfu",
+		`When the CIFS Unix Extensions are not negotiated, attempt to create device files and fifos in a format compatible with Services for Unix (SFU). In addition retrieve bits 10-12 of the mode via the SETFILEBITS extended attribute (as SFU does). In the future the bottom 9 bits of the mode mode also will be emulated using queries of the security descriptor (ACL). [NB: requires version 1.39 or later of the CIFS VFS. To recognize symlinks and be able to create symlinks in an SFU interoperable form requires version 1.40 or later of the CIFS VFS kernel module.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"serverino",
+		`Use inode numbers (unique persistent file identifiers) returned by the server instead of automatically generating temporary inode numbers on the client. Although server inode numbers make it easier to spot hardlinked files (as they will have the same inode numbers) and inode numbers may be persistent (which is userful for some sofware), the server does not guarantee that the inode numbers are unique if multiple server side mounts are exported under a single share (since inode numbers on the servers might not be unique if multiple filesystems are mounted under the same shared higher level directory). Note that not all servers support returning server inode numbers, although those that support the CIFS Unix Extensions, and Windows 2000 and later servers typically do support this (although not necessarily on every local server filesystem). Parameter has no effect if the server lacks support for returning inode numbers or equivalent. This behavior is enabled by default.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"noserverino",
+		`Client generates inode numbers itself rather than using the actual ones from the server.
+See section INODE NUMBERS for more information.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"nounix",
+		`Disable the CIFS Unix Extensions for this mount. This can be useful in order to turn off multiple settings at once. This includes POSIX acls, POSIX locks, POSIX paths, symlink support and retrieving uids/gids/mode from the server. This can also be useful to work around a bug in a server that supports Unix Extensions.
+See section INODE NUMBERS for more information.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"nouser_xattr",
+		`(default) Do not allow getfattr/setfattr to get/set xattrs, even if server would support it otherwise.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"fsc",
+		`Enable local disk caching using FS-Cache for CIFS. This option could be useful to improve performance on a slow link, heavily loaded server and/or network where reading from the disk is faster than reading from the server (over the network). This could also impact the scalability positively as the number of calls to the server are reduced. But, be warned that local caching is not suitable for all workloads, for e.g., read-once type workloads. So, you need to consider carefully the situation/workload before using this option. Currently, local disk caching is enabled for CIFS files opened as read-only.
+NOTE: This feature is available only in the recent kernels that have been built with the kernel config option CONFIG_CIFS_FSCACHE. You also need to have cachefilesd daemon installed and running to make the cache operational.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"multiuser",
+		`Map user accesses to individual credentials when accessing the server. By default, CIFS mounts only use a single set of user credentials (the mount credentials) when accessing a share. With this option, the client instead creates a new session with the server using the user's credentials whenever a new user accesses the mount. Further accesses by that user will also use those credentials. Because the kernel cannot prompt for passwords, multiuser mounts are limited to mounts using sec= options that don't require passwords.
+With this change, it's feasible for the server to handle permissions enforcement, so this option also implies "noperm". Furthermore, when unix extensions aren't in use and the administrator has not overriden ownership using the uid= or gid= options, ownership of files is presented as the current user accessing the share.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"noposixpaths",
+		`If unix extensions are enabled on a share, then the client will typically allow filenames to include any character besides '/' in a pathname component, and will use forward slashes as a pathname delimiter. This option prevents the client from attempting to negotiate the use of posix-style pathnames to the server.`,
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"posixpaths",
+		`Inverse of noposixpaths.`,
+	),
+}

--- a/server/common-documentation/mnt-cifs.go
+++ b/server/common-documentation/mnt-cifs.go
@@ -153,9 +153,9 @@ If the server requires signing during protocol negotiation, then it may be enabl
 			'm': {},
 		},
 		AllowByteSuffix: false,
-		Base: docvalues.DataAmountValueBase1024,
-		AllowDecimal: false,
-		Validator: docvalues.CreateDARangeValidator("2048", "127K", docvalues.DataAmountValueBase1024),
+		Base:            docvalues.DataAmountValueBase1024,
+		AllowDecimal:    false,
+		Validator:       docvalues.CreateDARangeValidator("2048", "127K", docvalues.DataAmountValueBase1024),
 	},
 	docvalues.CreateEnumStringWithDoc(
 		"wsize",

--- a/server/common-documentation/mnt-zfs.go
+++ b/server/common-documentation/mnt-zfs.go
@@ -1,0 +1,519 @@
+package commondocumentation
+
+import docvalues "config-lsp/doc-values"
+
+// TODO: Add user properties
+
+var numericProp = docvalues.DataAmountValue{
+	AllowedUnits: map[rune]struct{}{
+		'k': {},
+		'm': {},
+		'g': {},
+		't': {},
+		'p': {},
+		'e': {},
+		'z': {},
+	},
+	AllowByteSuffix: true,
+	AllowDecimal:    true,
+	Base:            docvalues.DataAmountValueBase1024,
+}
+
+var ZfsDocumentationAssignable = map[docvalues.EnumString]docvalues.DeprecatedValue{
+	docvalues.CreateEnumStringWithDoc(
+		"context",
+		"Sets the SELinux context for all files in the file system. This option is used to set the security context for SELinux-enabled systems.",
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"fscontext",
+		"Sets the SELinux context for the filesystem itself. This is used to set the security context for the filesystem as a whole.",
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"defcontext",
+		"Sets the default SELinux context for files that do not have a specific context set.",
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"rootcontext",
+		"Sets the SELinux context for the root directory of the filesystem.",
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"aclinherit",
+		"Controls how ACEs are inherited when files and directories are created.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("discard", "does not inherit any ACEs"),
+			docvalues.CreateEnumStringWithDoc("noallow", "only inherits inheritable ACEs specifying deny permissions"),
+			docvalues.CreateEnumStringWithDoc("restricted", "removes write_acl and write_owner permissions when inherited"),
+			docvalues.CreateEnumStringWithDoc("passthrough", "inherits all inheritable ACEs without modifications"),
+			docvalues.CreateEnumStringWithDoc("passthrough-x", "similar to passthrough, with execute permission nuances"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"aclmode",
+		"Controls ACL modification during chmod operations.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("discard", "deletes all ACEs except those representing file mode"),
+			docvalues.CreateEnumStringWithDoc("groupmask", "reduces permissions in ALLOW entries"),
+			docvalues.CreateEnumStringWithDoc("passthrough", "no changes to ACL"),
+			docvalues.CreateEnumStringWithDoc("restricted", "prevents chmod on files with non-trivial ACLs"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"acltype",
+		"Controls ACL type and enablement.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("off", "ACLs disabled"),
+			docvalues.CreateEnumStringWithDoc("nfsv4", "NFSv4-style ACLs"),
+			docvalues.CreateEnumStringWithDoc("posix", "POSIX ACLs"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"checksum",
+		"Controls data integrity verification algorithm.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "automatically selects algorithm"),
+			docvalues.CreateEnumStringWithDoc("off", "disables integrity checking"),
+			docvalues.CreateEnumStringWithDoc("fletcher2", "Fletcher2 checksum algorithm"),
+			docvalues.CreateEnumStringWithDoc("fletcher4", "Fletcher4 checksum algorithm"),
+			docvalues.CreateEnumStringWithDoc("sha256", "SHA256 checksum algorithm"),
+			docvalues.CreateEnumStringWithDoc("sha512", "SHA512 checksum algorithm"),
+			docvalues.CreateEnumStringWithDoc("skein", "Skein checksum algorithm"),
+			docvalues.CreateEnumStringWithDoc("edonr", "Edon-R checksum algorithm"),
+			docvalues.CreateEnumStringWithDoc("blake3", "BLAKE3 checksum algorithm"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"compression",
+		"Controls data compression algorithm.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "uses default compression"),
+			docvalues.CreateEnumStringWithDoc("off", "no compression"),
+			docvalues.CreateEnumStringWithDoc("gzip", "gzip compression"),
+			docvalues.CreateEnumStringWithDoc("gzip-1", "gzip compression level 1"),
+			docvalues.CreateEnumStringWithDoc("gzip-2", "gzip compression level 2"),
+			docvalues.CreateEnumStringWithDoc("gzip-3", "gzip compression level 3"),
+			docvalues.CreateEnumStringWithDoc("gzip-4", "gzip compression level 4"),
+			docvalues.CreateEnumStringWithDoc("gzip-5", "gzip compression level 5"),
+			docvalues.CreateEnumStringWithDoc("gzip-6", "gzip compression level 6"),
+			docvalues.CreateEnumStringWithDoc("gzip-7", "gzip compression level 7"),
+			docvalues.CreateEnumStringWithDoc("gzip-8", "gzip compression level 8"),
+			docvalues.CreateEnumStringWithDoc("gzip-9", "gzip compression level 9"),
+			docvalues.CreateEnumStringWithDoc("lz4", "LZ4 compression"),
+			docvalues.CreateEnumStringWithDoc("lzjb", "LZJB compression"),
+			docvalues.CreateEnumStringWithDoc("zle", "Zero Length Encoding"),
+			docvalues.CreateEnumStringWithDoc("zstd", "Zstandard compression"),
+			docvalues.CreateEnumStringWithDoc("zstd-1", "Zstandard compression level 1"),
+			docvalues.CreateEnumStringWithDoc("zstd-2", "Zstandard compression level 2"),
+			docvalues.CreateEnumStringWithDoc("zstd-3", "Zstandard compression level 3"),
+			docvalues.CreateEnumStringWithDoc("zstd-4", "Zstandard compression level 4"),
+			docvalues.CreateEnumStringWithDoc("zstd-5", "Zstandard compression level 5"),
+			docvalues.CreateEnumStringWithDoc("zstd-6", "Zstandard compression level 6"),
+			docvalues.CreateEnumStringWithDoc("zstd-7", "Zstandard compression level 7"),
+			docvalues.CreateEnumStringWithDoc("zstd-8", "Zstandard compression level 8"),
+			docvalues.CreateEnumStringWithDoc("zstd-9", "Zstandard compression level 9"),
+			docvalues.CreateEnumStringWithDoc("zstd-10", "Zstandard compression level 10"),
+			docvalues.CreateEnumStringWithDoc("zstd-11", "Zstandard compression level 11"),
+			docvalues.CreateEnumStringWithDoc("zstd-12", "Zstandard compression level 12"),
+			docvalues.CreateEnumStringWithDoc("zstd-13", "Zstandard compression level 13"),
+			docvalues.CreateEnumStringWithDoc("zstd-14", "Zstandard compression level 14"),
+			docvalues.CreateEnumStringWithDoc("zstd-15", "Zstandard compression level 15"),
+			docvalues.CreateEnumStringWithDoc("zstd-16", "Zstandard compression level 16"),
+			docvalues.CreateEnumStringWithDoc("zstd-17", "Zstandard compression level 17"),
+			docvalues.CreateEnumStringWithDoc("zstd-18", "Zstandard compression level 18"),
+			docvalues.CreateEnumStringWithDoc("zstd-19", "Zstandard compression level 19"),
+			docvalues.CreateEnumStringWithDoc("zstd-fast-1", "Zstandard fast compression level 1"),
+			docvalues.CreateEnumStringWithDoc("zstd-fast-2", "Zstandard fast compression level 2"),
+			docvalues.CreateEnumStringWithDoc("zstd-fast-3", "Zstandard fast compression level 3"),
+			docvalues.CreateEnumStringWithDoc("zstd-fast-4", "Zstandard fast compression level 4"),
+			docvalues.CreateEnumStringWithDoc("zstd-fast-5", "Zstandard fast compression level 5"),
+			docvalues.CreateEnumStringWithDoc("zstd-fast-6", "Zstandard fast compression level 6"),
+			docvalues.CreateEnumStringWithDoc("zstd-fast-7", "Zstandard fast compression level 7"),
+			docvalues.CreateEnumStringWithDoc("zstd-fast-8", "Zstandard fast compression level 8"),
+			docvalues.CreateEnumStringWithDoc("zstd-fast-9", "Zstandard fast compression level 9"),
+			docvalues.CreateEnumStringWithDoc("zstd-fast-10", "Zstandard fast compression level 10"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"copies",
+		"Controls the number of copies of data stored for this dataset. These copies are in addition to any redundancy provided by the pool.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("1", "single copy"),
+			docvalues.CreateEnumStringWithDoc("2", "two copies"),
+			docvalues.CreateEnumStringWithDoc("3", "three copies"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"dedup",
+		"Controls whether deduplication is enabled for this dataset.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "enable deduplication"),
+			docvalues.CreateEnumStringWithDoc("off", "disable deduplication"),
+			docvalues.CreateEnumStringWithDoc("verify", "enable deduplication with verification"),
+			docvalues.CreateEnumStringWithDoc("sha256", "enable deduplication using SHA256"),
+			docvalues.CreateEnumStringWithDoc("sha256,verify", "enable deduplication using SHA256 with verification"),
+			docvalues.CreateEnumStringWithDoc("sha512", "enable deduplication using SHA512"),
+			docvalues.CreateEnumStringWithDoc("sha512,verify", "enable deduplication using SHA512 with verification"),
+			docvalues.CreateEnumStringWithDoc("skein", "enable deduplication using Skein"),
+			docvalues.CreateEnumStringWithDoc("skein,verify", "enable deduplication using Skein with verification"),
+			docvalues.CreateEnumStringWithDoc("edonr", "enable deduplication using Edon-R"),
+			docvalues.CreateEnumStringWithDoc("edonr,verify", "enable deduplication using Edon-R with verification"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"logbias",
+		"Provides a hint to ZFS about handling of synchronous requests in this dataset.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("latency", "optimize for low latency"),
+			docvalues.CreateEnumStringWithDoc("throughput", "optimize for high throughput"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"primarycache",
+		"Controls what is cached in the primary cache (ARC).",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("all", "cache both metadata and data"),
+			docvalues.CreateEnumStringWithDoc("none", "cache neither metadata nor data"),
+			docvalues.CreateEnumStringWithDoc("metadata", "cache only metadata"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"quota",
+		"Limits the amount of disk space a dataset and its descendents can consume.",
+	): numericProp,
+	docvalues.CreateEnumStringWithDoc(
+		"recordsize",
+		"Specifies a suggested block size for files in the filesystem.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("512", "512 bytes"),
+			docvalues.CreateEnumStringWithDoc("1K", "1 KB"),
+			docvalues.CreateEnumStringWithDoc("2K", "2 KB"),
+			docvalues.CreateEnumStringWithDoc("4K", "4 KB"),
+			docvalues.CreateEnumStringWithDoc("8K", "8 KB"),
+			docvalues.CreateEnumStringWithDoc("16K", "16 KB"),
+			docvalues.CreateEnumStringWithDoc("32K", "32 KB"),
+			docvalues.CreateEnumStringWithDoc("64K", "64 KB"),
+			docvalues.CreateEnumStringWithDoc("128K", "128 KB"),
+			docvalues.CreateEnumStringWithDoc("256K", "256 KB"),
+			docvalues.CreateEnumStringWithDoc("512K", "512 KB"),
+			docvalues.CreateEnumStringWithDoc("1M", "1 MB"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"refquota",
+		"Limits the amount of space a dataset can consume. This hard limit does not include space used by descendents.",
+	): numericProp,
+	docvalues.CreateEnumStringWithDoc(
+		"refreservation",
+		"The minimum amount of space guaranteed to a dataset, not including its descendents.",
+	): numericProp,
+	docvalues.CreateEnumStringWithDoc(
+		"reservation",
+		"The minimum amount of space guaranteed to a dataset and its descendents.",
+	): numericProp,
+	docvalues.CreateEnumStringWithDoc(
+		"secondarycache",
+		"Controls what is cached in the secondary cache (L2ARC).",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("all", "cache both metadata and data"),
+			docvalues.CreateEnumStringWithDoc("none", "cache neither metadata nor data"),
+			docvalues.CreateEnumStringWithDoc("metadata", "cache only metadata"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"snapdir",
+		"Controls whether the .zfs directory is hidden or visible in the root of the filesystem.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("hidden", "hide .zfs directory"),
+			docvalues.CreateEnumStringWithDoc("visible", "show .zfs directory"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"sync",
+		"Controls the behavior of synchronous requests.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("standard", "honor synchronous requests"),
+			docvalues.CreateEnumStringWithDoc("always", "every write is synchronous"),
+			docvalues.CreateEnumStringWithDoc("disabled", "disable synchronous requests"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"version",
+		"The on-disk version of this filesystem.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("1", "version 1"),
+			docvalues.CreateEnumStringWithDoc("2", "version 2"),
+			docvalues.CreateEnumStringWithDoc("3", "version 3"),
+			docvalues.CreateEnumStringWithDoc("4", "version 4"),
+			docvalues.CreateEnumStringWithDoc("5", "version 5"),
+			docvalues.CreateEnumStringWithDoc("current", "current version"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"volsize",
+		"For volumes, specifies the logical size of the volume.",
+	): numericProp,
+	docvalues.CreateEnumStringWithDoc(
+		"xattr",
+		"Controls whether extended attributes are enabled for this filesystem.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "enable extended attributes using system attribute directory"),
+			docvalues.CreateEnumStringWithDoc("off", "disable extended attributes"),
+			docvalues.CreateEnumStringWithDoc("dir", "enable extended attributes using directory-based storage"),
+			docvalues.CreateEnumStringWithDoc("sa", "enable extended attributes using system attribute storage"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"zoned",
+		"Controls whether the dataset is managed from a non-global zone.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "dataset is managed from a non-global zone"),
+			docvalues.CreateEnumStringWithDoc("off", "dataset is managed from the global zone"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"redundant_metadata",
+		"Controls what types of metadata are stored redundantly.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("all", "store all metadata redundantly"),
+			docvalues.CreateEnumStringWithDoc("most", "store most metadata redundantly"),
+			docvalues.CreateEnumStringWithDoc("some", "store some metadata redundantly"),
+			docvalues.CreateEnumStringWithDoc("none", "store no metadata redundantly"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"special_small_blocks",
+		"Threshold block size for including small file or zvol blocks into special allocation class.",
+	): numericProp,
+	docvalues.CreateEnumStringWithDoc(
+		"filesystem_limit",
+		"Limits number of filesystems and volumes under this point in dataset tree.",
+	): numericProp,
+	docvalues.CreateEnumStringWithDoc(
+		"snapshot_limit",
+		"Limits number of snapshots that can be created on a dataset.",
+	): numericProp,
+	docvalues.CreateEnumStringWithDoc(
+		"canmount",
+		"Controls whether file system can be mounted.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "filesystem can be mounted"),
+			docvalues.CreateEnumStringWithDoc("off", "filesystem cannot be mounted"),
+			docvalues.CreateEnumStringWithDoc("noauto", "filesystem can be mounted but not automatically"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"mountpoint",
+		"Controls mount point used for file system.",
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"sharenfs",
+		"Controls NFS sharing and options.",
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"sharesmb",
+		"Controls SMB sharing.",
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"dnodesize",
+		"Specifies size of dnodes in file system.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("legacy", "use legacy dnode size"),
+			docvalues.CreateEnumStringWithDoc("auto", "automatically select dnode size"),
+			docvalues.CreateEnumStringWithDoc("1k", "1 KB dnode size"),
+			docvalues.CreateEnumStringWithDoc("2k", "2 KB dnode size"),
+			docvalues.CreateEnumStringWithDoc("4k", "4 KB dnode size"),
+			docvalues.CreateEnumStringWithDoc("8k", "8 KB dnode size"),
+			docvalues.CreateEnumStringWithDoc("16k", "16 KB dnode size"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"encryption",
+		"Controls encryption cipher suite.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("off", "no encryption"),
+			docvalues.CreateEnumStringWithDoc("on", "use default encryption"),
+			docvalues.CreateEnumStringWithDoc("aes-128-ccm", "AES-128-CCM encryption"),
+			docvalues.CreateEnumStringWithDoc("aes-192-ccm", "AES-192-CCM encryption"),
+			docvalues.CreateEnumStringWithDoc("aes-256-ccm", "AES-256-CCM encryption"),
+			docvalues.CreateEnumStringWithDoc("aes-128-gcm", "AES-128-GCM encryption"),
+			docvalues.CreateEnumStringWithDoc("aes-192-gcm", "AES-192-GCM encryption"),
+			docvalues.CreateEnumStringWithDoc("aes-256-gcm", "AES-256-GCM encryption"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"keylocation",
+		"Controls where encryption key is loaded from.",
+	): docvalues.StringValue{},
+	docvalues.CreateEnumStringWithDoc(
+		"keyformat",
+		"Controls encryption key format.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("raw", "raw key format"),
+			docvalues.CreateEnumStringWithDoc("hex", "hexadecimal key format"),
+			docvalues.CreateEnumStringWithDoc("passphrase", "passphrase key format"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"pbkdf2iters",
+		"Controls the number of PBKDF2 iterations used for generating encryption keys from passphrases.",
+	): docvalues.NumberRangeValue(100000, 1000000000),
+	docvalues.CreateEnumStringWithDoc(
+		"devices",
+		"Controls whether device nodes can be opened on this file system.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "allow device nodes"),
+			docvalues.CreateEnumStringWithDoc("off", "disallow device nodes"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"setuid",
+		"Controls whether the setuid bit is respected for the file system.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "respect setuid bits"),
+			docvalues.CreateEnumStringWithDoc("off", "ignore setuid bits"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"readonly",
+		"Controls whether this dataset can be modified.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "read-only access"),
+			docvalues.CreateEnumStringWithDoc("off", "read-write access"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"atime",
+		"Controls whether file access times are updated when they are read.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "update access times"),
+			docvalues.CreateEnumStringWithDoc("off", "do not update access times"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"relatime",
+		"Controls the manner in which the access time is updated.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "update access time relative to modify time"),
+			docvalues.CreateEnumStringWithDoc("off", "disable relative access time updates"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"nbmand",
+		"Controls whether the file system should be mounted with non-blocking mandatory locks.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "enable non-blocking mandatory locks"),
+			docvalues.CreateEnumStringWithDoc("off", "disable non-blocking mandatory locks"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"vscan",
+		"Controls whether regular files should be scanned for viruses when a file is opened and closed. In addition to enabling this property, the virus scan service must also be enabled for virus scanning to occur. The default value is off. This property is not used by OpenZFS.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "enable virus scanning"),
+			docvalues.CreateEnumStringWithDoc("off", "disable virus scanning"),
+		},
+	},
+	docvalues.CreateEnumStringWithDoc(
+		"jailed",
+		"Controls whether the dataset is managed from a jail. See zfs-jail(8) for more information. Jails are a FreeBSD feature and this property is not available on other platforms.",
+	): docvalues.EnumValue{
+		Values: []docvalues.EnumString{
+			docvalues.CreateEnumStringWithDoc("on", "dataset is managed from a jail"),
+			docvalues.CreateEnumStringWithDoc("off", "dataset is not managed from a jail"),
+		},
+	},
+}
+
+var ZfsDocumentationEnums = []docvalues.EnumString{
+	docvalues.CreateEnumStringWithDoc(
+		"dev",
+		"Controls whether device nodes can be opened on this file system. This is the default behavior.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"nodev",
+		"Controls whether device nodes can be opened on this file system. When set, device nodes cannot be opened.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"exec",
+		"Controls whether processes can be executed from within this file system. This is the default behavior.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"noexec",
+		"Controls whether processes can be executed from within this file system. When set, executables cannot be run from this filesystem.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"ro",
+		"Controls whether this dataset can be modified. When set, the filesystem is mounted read-only.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"rw",
+		"Controls whether this dataset can be modified. This is the default behavior allowing read-write access.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"suid",
+		"Controls whether the setuid bit is respected for the file system. This is the default behavior.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"nosuid",
+		"Controls whether the setuid bit is respected for the file system. When set, setuid and setgid bits are ignored.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"devices",
+		"Controls whether device nodes can be opened on this file system. This is the default behavior.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"nodevices",
+		"Controls whether device nodes can be opened on this file system. When set, device nodes cannot be opened.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"setuid",
+		"Controls whether the setuid bit is respected for the file system. This is the default behavior.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"nosetuid",
+		"Controls whether the setuid bit is respected for the file system. When set, setuid and setgid bits are ignored.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"readonly",
+		"Controls whether this dataset can be modified. When set, the filesystem is mounted read-only.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"readwrite",
+		"Controls whether this dataset can be modified. This is the default behavior allowing read-write access.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"overlay",
+		"Allow mounting on busy or populated directory.",
+	),
+	docvalues.CreateEnumStringWithDoc(
+		"nooverlay",
+		"Disallow mounting on busy or populated directory.",
+	),
+}

--- a/server/common/location.go
+++ b/server/common/location.go
@@ -186,8 +186,8 @@ func (c CursorPosition) getValue() uint32 {
 	return uint32(c)
 }
 
-func (c CursorPosition) ShiftHorizontal(offset uint32) CursorPosition {
-	return CursorPosition(uint32(c) + offset)
+func (c CursorPosition) ShiftHorizontal(offset int) CursorPosition {
+	return CursorPosition(uint32(int(c) + offset))
 }
 
 func LSPCharacterAsCursorPosition(character uint32) CursorPosition {

--- a/server/common/location.go
+++ b/server/common/location.go
@@ -204,7 +204,7 @@ func (c CursorPosition) IsAfterIndexPosition(i IndexPosition) bool {
 	return uint32(c) > uint32(i)+1
 }
 
-// Get the rune that is before the cursor position
+// Get the byte that is before the cursor position
 // This expects that the cursor is not out of bounds
 func (c CursorPosition) GetCharacterBefore(value string) byte {
 	if c.getValue() == 0 {
@@ -212,6 +212,21 @@ func (c CursorPosition) GetCharacterBefore(value string) byte {
 	} else {
 		return value[max(0, c.getValue()-1)]
 	}
+}
+
+// Get the byte that is after the cursor position
+// This expects that the cursor is not out of bounds
+func (c CursorPosition) GetCharacterAfter(value string) byte {
+	if c.getValue() >= uint32(len(value)) {
+		return value[len(value)-1]
+	} else {
+		return value[c.getValue()]
+	}
+}
+
+func (c CursorPosition) IsAtEdge(value string) bool {
+	// If the cursor is at the start or end of the value
+	return c.getValue() == 0 || c.getValue() >= uint32(len(value))
 }
 
 // Use this type if you want to use an index based position

--- a/server/common/location.go
+++ b/server/common/location.go
@@ -186,7 +186,7 @@ func (c CursorPosition) getValue() uint32 {
 	return uint32(c)
 }
 
-func (c CursorPosition) shiftHorizontal(offset uint32) CursorPosition {
+func (c CursorPosition) ShiftHorizontal(offset uint32) CursorPosition {
 	return CursorPosition(uint32(c) + offset)
 }
 
@@ -202,6 +202,16 @@ func (c CursorPosition) IsBeforeIndexPosition(i IndexPosition) bool {
 func (c CursorPosition) IsAfterIndexPosition(i IndexPosition) bool {
 	// H[e]|llo
 	return uint32(c) > uint32(i)+1
+}
+
+// Get the rune that is before the cursor position
+// This expects that the cursor is not out of bounds
+func (c CursorPosition) GetCharacterBefore(value string) byte {
+	if c.getValue() == 0 {
+		return value[0]
+	} else {
+		return value[max(0, c.getValue()-1)]
+	}
 }
 
 // Use this type if you want to use an index based position

--- a/server/common/lsp.go
+++ b/server/common/lsp.go
@@ -17,7 +17,7 @@ func DeprecatedImprovedCursorToIndex(
 		return 0
 	}
 
-	return min(uint32(len(line)-1), uint32(c)-offset+1)
+	return min(uint32(len(line)-1), uint32(c)-offset)
 }
 
 var SeverityError = protocol.DiagnosticSeverityError

--- a/server/doc-values/base-value.go
+++ b/server/doc-values/base-value.go
@@ -1,7 +1,9 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"config-lsp/utils"
+
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
@@ -10,6 +12,8 @@ type DeprecatedValue interface {
 	DeprecatedCheckIsValid(value string) []*InvalidValue
 	DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem
 	DeprecatedFetchHoverInfo(line string, cursor uint32) []string
+
+	FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem
 }
 
 type InvalidValue struct {

--- a/server/doc-values/base-value.go
+++ b/server/doc-values/base-value.go
@@ -10,7 +10,6 @@ import (
 type DeprecatedValue interface {
 	GetTypeDescription() []string
 	DeprecatedCheckIsValid(value string) []*InvalidValue
-	DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem
 	DeprecatedFetchHoverInfo(line string, cursor uint32) []string
 
 	FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem

--- a/server/doc-values/value-array.go
+++ b/server/doc-values/value-array.go
@@ -10,11 +10,11 @@ import (
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
-type ArrayContainsDuplicatesError struct {
+type ValueArrayContainsDuplicatesError struct {
 	Value string
 }
 
-func (e ArrayContainsDuplicatesError) Error() string {
+func (e ValueArrayContainsDuplicatesError) Error() string {
 	return fmt.Sprintf("'%s' is a duplicate value (and duplicates are not allowed)", e.Value)
 }
 
@@ -93,7 +93,7 @@ func (v ArrayValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 			if _, found := valueSet[extractedValue]; found {
 				// This value is a duplicate, so we add an error
 				errors = append(errors, &InvalidValue{
-					Err: ArrayContainsDuplicatesError{
+					Err: ValueArrayContainsDuplicatesError{
 						Value: rawValue,
 					},
 					Start: currentIndex,

--- a/server/doc-values/value-array.go
+++ b/server/doc-values/value-array.go
@@ -244,5 +244,16 @@ func (v ArrayValue) FetchCompletions(value string, cursor common.CursorPosition)
 }
 
 func (v ArrayValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {
-	return nil
+	// TODO: Replace DeprecatedFetchHoverInfo with FetchHoverInfo and make sure cursor is a common.CursorPosition
+	value, newCursor := v.getCurrentValue(line, common.CursorPosition(cursor))
+
+	if v.RespectQuotes && !v.PersistQuotes {
+		value, newCursor = v.unwrapQuotes(value, common.CursorPosition(newCursor))
+	}
+
+	if len(value) == 0 {
+		return []string{}
+	}
+
+	return v.SubValue.DeprecatedFetchHoverInfo(value, uint32(newCursor))
 }

--- a/server/doc-values/value-array.go
+++ b/server/doc-values/value-array.go
@@ -47,6 +47,10 @@ type ArrayValue struct {
 
 	// If true, array ArrayValue ignores the `Separator` if it's within quotes
 	RespectQuotes bool
+
+	// If true, the quotes will not be unwrapped and the raw string will be passed
+	// to the subvalue
+	PersistQuotes bool
 }
 
 func (v ArrayValue) GetTypeDescription() []string {
@@ -71,7 +75,7 @@ func (v ArrayValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 		values = strings.Split(value, v.Separator)
 	}
 
-	if *v.DuplicatesExtractor != nil {
+	if v.DuplicatesExtractor != nil && *v.DuplicatesExtractor != nil {
 		// Stores the values that are already found
 		valueSet := map[string]struct{}{}
 
@@ -125,14 +129,14 @@ func (v ArrayValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 }
 
 func (v ArrayValue) getCurrentValue(line string, cursor common.CursorPosition) (string, common.CursorPosition) {
-	index := common.DeprecatedImprovedCursorToIndex(cursor, line, 0)
+	index := max(uint32(cursor), 1) - 1
 
 	if line == "" {
 		return line, 0
 	}
 
 	MIN := uint32(0)
-	MAX := uint32(len(line) - 1)
+	MAX := uint32(len(line))
 
 	var indexSearchStart = index
 	var indexSearchEnd = index
@@ -169,43 +173,74 @@ func (v ArrayValue) getCurrentValue(line string, cursor common.CursorPosition) (
 	)
 
 	if found {
+		// Edge case, two separators in a row
+		// -> value is empty
+		if relativePosition < (len(line)-1) && line[relativePosition+1] == v.Separator[0] {
+			return "", 0
+		}
+
+		// Edge case, separator at start
+		if relativePosition == 0 && cursor == 0 {
+			return "", 0
+		}
+
 		// + 1 to skip the separator
 		start = min(
 			MAX,
 			uint32(relativePosition)+1,
 		)
+		indexSearchEnd += 1
 	} else {
 		start = MIN
 	}
 
-	relativePosition, found = utils.FindNextCharacter(
-		line,
-		v.Separator,
-		int(indexSearchEnd),
-	)
-
-	if found {
-		// - 1 to skip the separator
-		end = max(
-			MIN,
-			uint32(relativePosition)-1,
-		)
-	} else {
+	if indexSearchEnd >= uint32(len(line)) {
 		end = MAX
+	} else {
+
+		relativePosition, found = utils.FindNextCharacter(
+			line,
+			v.Separator,
+			int(indexSearchEnd),
+		)
+
+		if found {
+			// - 1 to skip the separator
+			end = max(
+				MIN,
+				uint32(relativePosition)-1,
+			) + 1
+		} else {
+			end = MAX
+		}
+
 	}
 
-	if index > end {
-		// The user is typing a new (yet empty) value
-		return "", 0
+	return line[start:end], cursor.ShiftHorizontal(-start)
+}
+
+func (v ArrayValue) unwrapQuotes(value string, cursor common.CursorPosition) (string, common.CursorPosition) {
+	if v.RespectQuotes && !v.PersistQuotes && len(value) >= 1 {
+		newValue := strings.TrimSuffix(strings.TrimPrefix(value, "\""), "\"")
+
+		if value[0] == '"' && cursor <= 1 {
+			return newValue, 0
+		}
+
+		if value[len(value)-1] == '"' && uint32(cursor) >= uint32(len(value))-1 {
+			return newValue, common.CursorPosition(uint32(len(value)))
+		}
 	}
 
-	return line[start : end+1], cursor.ShiftHorizontal(-start)
+	// Nothing to do
+	return value, cursor
 }
 
 func (v ArrayValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	relativeValue, relativeCursor := v.getCurrentValue(value, cursor)
+	newValue, newCursor := v.unwrapQuotes(relativeValue, relativeCursor)
 
-	return v.SubValue.FetchCompletions(relativeValue, relativeCursor)
+	return v.SubValue.FetchCompletions(newValue, newCursor)
 }
 
 func (v ArrayValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-array.go
+++ b/server/doc-values/value-array.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"config-lsp/utils"
 	"fmt"
 	"regexp"
@@ -203,6 +204,17 @@ func (v ArrayValue) DeprecatedFetchCompletions(line string, cursor uint32) []pro
 	value, cursor := v.getCurrentValue(line, cursor)
 
 	return v.SubValue.DeprecatedFetchCompletions(value, cursor)
+}
+
+func (v ArrayValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v ArrayValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-array_test.go
+++ b/server/doc-values/value-array_test.go
@@ -1,0 +1,233 @@
+package docvalues
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestVAValidExample1(t *testing.T) {
+	value := ArrayValue{
+		SubValue: RegexValue{
+			Regex: *regexp.MustCompile(`^\d+$`),
+		},
+		Separator:           ",",
+		RespectQuotes:       false,
+		DuplicatesExtractor: nil,
+	}
+
+	line := "1,212,3445"
+	errs := value.DeprecatedCheckIsValid(line)
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+
+	val1, val1Cursor := value.getCurrentValue(line, 0)
+	if !(val1 == "1" && val1Cursor == 0) {
+		t.Errorf("Expected first value to be '1' at cursor 0, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val1, val1Cursor = value.getCurrentValue(line, 1)
+	if !(val1 == "1" && val1Cursor == 1) {
+		t.Errorf("Expected first value to be '1' at cursor 1, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val2, val2Cursor := value.getCurrentValue(line, 2)
+	if !(val2 == "212" && val2Cursor == 0) {
+		t.Errorf("Expected second value to be '212' at cursor 2, got '%s' at %d", val2, val2Cursor)
+	}
+
+	val2, val2Cursor = value.getCurrentValue(line, 3)
+	if !(val2 == "212" && val2Cursor == 1) {
+		t.Errorf("Expected second value to be '212' at cursor 3, got '%s' at %d", val2, val2Cursor)
+	}
+
+	val2, val2Cursor = value.getCurrentValue(line, 5)
+	if !(val2 == "212" && val2Cursor == 3) {
+		t.Errorf("Expected second value to be '212' at cursor 5, got '%s' at %d", val2, val2Cursor)
+	}
+
+	val3, val3Cursor := value.getCurrentValue(line, 6)
+	if !(val3 == "3445" && val3Cursor == 0) {
+		t.Errorf("Expected third value to be '3445' at cursor 6, got '%s' at %d", val3, val3Cursor)
+	}
+
+	val3, val3Cursor = value.getCurrentValue(line, 9)
+	if !(val3 == "3445" && val3Cursor == 3) {
+		t.Errorf("Expected third value to be '3445' at cursor 9, got '%s' at %d", val3, val3Cursor)
+	}
+
+	val3, val3Cursor = value.getCurrentValue(line, 10)
+	if !(val3 == "3445" && val3Cursor == 4) {
+		t.Errorf("Expected third value to be '3445' at cursor 10, got '%s' at %d", val3, val3Cursor)
+	}
+}
+
+func TestVAEdgeCaseAtStart(t *testing.T) {
+	value := ArrayValue{
+		SubValue: RegexValue{
+			Regex: *regexp.MustCompile(`^\d*$`),
+		},
+		Separator:           ",",
+		RespectQuotes:       false,
+		DuplicatesExtractor: nil,
+	}
+
+	line := ",1,212,3445"
+
+	errs := value.DeprecatedCheckIsValid(line)
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+
+	val1, val1Cursor := value.getCurrentValue(line, 0)
+	if !(val1 == "" && val1Cursor == 0) {
+		t.Errorf("Expected first value to be '' at cursor 0, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val2, val2Cursor := value.getCurrentValue(line, 1)
+	if !(val2 == "1" && val2Cursor == 0) {
+		t.Errorf("Expected second value to be '1' at cursor 1, got '%s' at %d", val2, val2Cursor)
+	}
+
+	val2, val2Cursor = value.getCurrentValue(line, 2)
+	if !(val2 == "1" && val2Cursor == 1) {
+		t.Errorf("Expected second value to be '1' at cursor 2, got '%s' at %d", val2, val2Cursor)
+	}
+
+	val3, val3Cursor := value.getCurrentValue(line, 3)
+	if !(val3 == "212" && val3Cursor == 0) {
+		t.Errorf("Expected third value to be '212' at cursor 3, got '%s' at %d", val3, val3Cursor)
+	}
+}
+
+func TestVAEdgeCaseAtMiddle(t *testing.T) {
+	value := ArrayValue{
+		SubValue: RegexValue{
+			Regex: *regexp.MustCompile(`^\d*$`),
+		},
+		Separator:           ",",
+		RespectQuotes:       false,
+		DuplicatesExtractor: nil,
+	}
+
+	line := "1,,212,3445"
+
+	errs := value.DeprecatedCheckIsValid(line)
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+
+	val1, val1Cursor := value.getCurrentValue(line, 0)
+	if !(val1 == "1" && val1Cursor == 0) {
+		t.Errorf("Expected first value to be '1' at cursor 0, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val1, val1Cursor = value.getCurrentValue(line, 1)
+	if !(val1 == "1" && val1Cursor == 1) {
+		t.Errorf("Expected first value to be '1' at cursor 1, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val2, val2Cursor := value.getCurrentValue(line, 2)
+	if !(val2 == "" && val2Cursor == 0) {
+		t.Errorf("Expected second value to be '' at cursor 2, got '%s' at %d", val2, val2Cursor)
+	}
+
+	val3, val3Cursor := value.getCurrentValue(line, 3)
+	if !(val3 == "212" && val3Cursor == 0) {
+		t.Errorf("Expected third value to be '212' at cursor 3, got '%s' at %d", val3, val3Cursor)
+	}
+}
+
+func TestVAEdgeCaseAtEnd(t *testing.T) {
+	value := ArrayValue{
+		SubValue: RegexValue{
+			Regex: *regexp.MustCompile(`^\d*$`),
+		},
+		Separator:           ",",
+		RespectQuotes:       false,
+		DuplicatesExtractor: nil,
+	}
+
+	line := "1,"
+
+	errs := value.DeprecatedCheckIsValid(line)
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+
+	val1, val1Cursor := value.getCurrentValue(line, 0)
+	if !(val1 == "1" && val1Cursor == 0) {
+		t.Errorf("Expected first value to be '1' at cursor 0, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val1, val1Cursor = value.getCurrentValue(line, 1)
+	if !(val1 == "1" && val1Cursor == 1) {
+		t.Errorf("Expected first value to be '1' at cursor 1, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val2, val2Cursor := value.getCurrentValue(line, 2)
+	if !(val2 == "" && val2Cursor == 0) {
+		t.Errorf("Expected second value to be '' at cursor 2, got '%s' at %d", val2, val2Cursor)
+	}
+}
+
+func TestVAValidExampleQuotes(t *testing.T) {
+	value := ArrayValue{
+		SubValue:      StringValue{},
+		Separator:     ",",
+		RespectQuotes: true,
+		PersistQuotes: false,
+	}
+
+	line := `"1,212",3445`
+
+	errs := value.DeprecatedCheckIsValid(line)
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+
+	val1, val1Cursor := value.getCurrentValue(line, 0)
+	if !(val1 == `"1,212"` && val1Cursor == 0) {
+		t.Errorf("Expected first value to be '1,212' at cursor 0, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val1, val1Cursor = value.getCurrentValue(line, 1)
+	if !(val1 == `"1,212"` && val1Cursor == 1) {
+		t.Errorf("Expected first value to be '1,212' at cursor 1, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val1, val1Cursor = value.getCurrentValue(line, 2)
+	if !(val1 == `"1,212"` && val1Cursor == 2) {
+		t.Errorf("Expected first value to be '1,212' at cursor 2, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val1, val1Cursor = value.getCurrentValue(line, 6)
+	if !(val1 == `"1,212"` && val1Cursor == 6) {
+		t.Errorf("Expected first value to be '1,212' at cursor 5, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val1, val1Cursor = value.getCurrentValue(line, 7)
+	if !(val1 == `"1,212"` && val1Cursor == 7) {
+		t.Errorf("Expected first value to be '1,212' at cursor 6, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val2, val2Cursor := value.getCurrentValue(line, 8)
+	if !(val2 == "3445" && val2Cursor == 0) {
+		t.Errorf("Expected second value to be '3445' at cursor 8, got '%s' at %d", val2, val2Cursor)
+	}
+
+	val2, val2Cursor = value.getCurrentValue(line, 9)
+	if !(val2 == "3445" && val2Cursor == 1) {
+		t.Errorf("Expected second value to be '3445' at cursor 9, got '%s' at %d", val2, val2Cursor)
+	}
+
+	val2, val2Cursor = value.getCurrentValue(line, 12)
+	if !(val2 == "3445" && val2Cursor == 4) {
+		t.Errorf("Expected second value to be '3445' at cursor 12, got '%s' at %d", val2, val2Cursor)
+	}
+}

--- a/server/doc-values/value-array_test.go
+++ b/server/doc-values/value-array_test.go
@@ -180,6 +180,71 @@ func TestVAValidExampleQuotes(t *testing.T) {
 		SubValue:      StringValue{},
 		Separator:     ",",
 		RespectQuotes: true,
+		PersistQuotes: true,
+	}
+
+	line := `"1,212",3445`
+
+	errs := value.DeprecatedCheckIsValid(line)
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+
+	val1, val1Cursor := value.getCurrentValue(line, 0)
+	val1, val1Cursor = value.unwrapQuotes(val1, val1Cursor)
+	if !(val1 == `"1,212"` && val1Cursor == 0) {
+		t.Errorf("Expected first value to be '1,212' at cursor 0, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val1, val1Cursor = value.getCurrentValue(line, 1)
+	val1, val1Cursor = value.unwrapQuotes(val1, val1Cursor)
+	if !(val1 == `"1,212"` && val1Cursor == 1) {
+		t.Errorf("Expected first value to be '1,212' at cursor 1, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val1, val1Cursor = value.getCurrentValue(line, 2)
+	val1, val1Cursor = value.unwrapQuotes(val1, val1Cursor)
+	if !(val1 == `"1,212"` && val1Cursor == 2) {
+		t.Errorf("Expected first value to be '1,212' at cursor 2, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val1, val1Cursor = value.getCurrentValue(line, 6)
+	val1, val1Cursor = value.unwrapQuotes(val1, val1Cursor)
+	if !(val1 == `"1,212"` && val1Cursor == 6) {
+		t.Errorf("Expected first value to be '1,212' at cursor 5, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val1, val1Cursor = value.getCurrentValue(line, 7)
+	val1, val1Cursor = value.unwrapQuotes(val1, val1Cursor)
+	if !(val1 == `"1,212"` && val1Cursor == 7) {
+		t.Errorf("Expected first value to be '1,212' at cursor 6, got '%s' at %d", val1, val1Cursor)
+	}
+
+	val2, val2Cursor := value.getCurrentValue(line, 8)
+	val2, val2Cursor = value.unwrapQuotes(val2, val2Cursor)
+	if !(val2 == "3445" && val2Cursor == 0) {
+		t.Errorf("Expected second value to be '3445' at cursor 8, got '%s' at %d", val2, val2Cursor)
+	}
+
+	val2, val2Cursor = value.getCurrentValue(line, 9)
+	val2, val2Cursor = value.unwrapQuotes(val2, val2Cursor)
+	if !(val2 == "3445" && val2Cursor == 1) {
+		t.Errorf("Expected second value to be '3445' at cursor 9, got '%s' at %d", val2, val2Cursor)
+	}
+
+	val2, val2Cursor = value.getCurrentValue(line, 12)
+	val2, val2Cursor = value.unwrapQuotes(val2, val2Cursor)
+	if !(val2 == "3445" && val2Cursor == 4) {
+		t.Errorf("Expected second value to be '3445' at cursor 12, got '%s' at %d", val2, val2Cursor)
+	}
+}
+
+func TestVAValidExampleQuotesNotPersist(t *testing.T) {
+	value := ArrayValue{
+		SubValue:      StringValue{},
+		Separator:     ",",
+		RespectQuotes: true,
 		PersistQuotes: false,
 	}
 
@@ -192,41 +257,49 @@ func TestVAValidExampleQuotes(t *testing.T) {
 	}
 
 	val1, val1Cursor := value.getCurrentValue(line, 0)
-	if !(val1 == `"1,212"` && val1Cursor == 0) {
+	val1, val1Cursor = value.unwrapQuotes(val1, val1Cursor)
+	if !(val1 == `1,212` && val1Cursor == 0) {
 		t.Errorf("Expected first value to be '1,212' at cursor 0, got '%s' at %d", val1, val1Cursor)
 	}
 
 	val1, val1Cursor = value.getCurrentValue(line, 1)
-	if !(val1 == `"1,212"` && val1Cursor == 1) {
+	val1, val1Cursor = value.unwrapQuotes(val1, val1Cursor)
+	if !(val1 == `1,212` && val1Cursor == 0) {
 		t.Errorf("Expected first value to be '1,212' at cursor 1, got '%s' at %d", val1, val1Cursor)
 	}
 
 	val1, val1Cursor = value.getCurrentValue(line, 2)
-	if !(val1 == `"1,212"` && val1Cursor == 2) {
+	val1, val1Cursor = value.unwrapQuotes(val1, val1Cursor)
+	if !(val1 == `1,212` && val1Cursor == 1) {
 		t.Errorf("Expected first value to be '1,212' at cursor 2, got '%s' at %d", val1, val1Cursor)
 	}
 
 	val1, val1Cursor = value.getCurrentValue(line, 6)
-	if !(val1 == `"1,212"` && val1Cursor == 6) {
+	val1, val1Cursor = value.unwrapQuotes(val1, val1Cursor)
+	if !(val1 == `1,212` && val1Cursor == 5) {
 		t.Errorf("Expected first value to be '1,212' at cursor 5, got '%s' at %d", val1, val1Cursor)
 	}
 
 	val1, val1Cursor = value.getCurrentValue(line, 7)
-	if !(val1 == `"1,212"` && val1Cursor == 7) {
+	val1, val1Cursor = value.unwrapQuotes(val1, val1Cursor)
+	if !(val1 == `1,212` && val1Cursor == 5) {
 		t.Errorf("Expected first value to be '1,212' at cursor 6, got '%s' at %d", val1, val1Cursor)
 	}
 
 	val2, val2Cursor := value.getCurrentValue(line, 8)
+	val2, val2Cursor = value.unwrapQuotes(val2, val2Cursor)
 	if !(val2 == "3445" && val2Cursor == 0) {
 		t.Errorf("Expected second value to be '3445' at cursor 8, got '%s' at %d", val2, val2Cursor)
 	}
 
 	val2, val2Cursor = value.getCurrentValue(line, 9)
+	val2, val2Cursor = value.unwrapQuotes(val2, val2Cursor)
 	if !(val2 == "3445" && val2Cursor == 1) {
 		t.Errorf("Expected second value to be '3445' at cursor 9, got '%s' at %d", val2, val2Cursor)
 	}
 
 	val2, val2Cursor = value.getCurrentValue(line, 12)
+	val2, val2Cursor = value.unwrapQuotes(val2, val2Cursor)
 	if !(val2 == "3445" && val2Cursor == 4) {
 		t.Errorf("Expected second value to be '3445' at cursor 12, got '%s' at %d", val2, val2Cursor)
 	}

--- a/server/doc-values/value-completions.go
+++ b/server/doc-values/value-completions.go
@@ -1,0 +1,33 @@
+package docvalues
+
+import (
+	"config-lsp/common"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Manually add extra completions
+type CompletionsValue struct {
+	Completions []protocol.CompletionItem
+	SubValue    DeprecatedValue
+}
+
+func (v CompletionsValue) GetTypeDescription() []string {
+	return v.SubValue.GetTypeDescription()
+}
+
+func (v CompletionsValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
+	return v.SubValue.DeprecatedCheckIsValid(value)
+}
+
+func (v CompletionsValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	completions := v.SubValue.FetchCompletions(value, cursor)
+
+	completions = append(completions, v.Completions...)
+
+	return completions
+}
+
+func (v CompletionsValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {
+	return v.SubValue.DeprecatedFetchHoverInfo(line, cursor)
+}

--- a/server/doc-values/value-custom.go
+++ b/server/doc-values/value-custom.go
@@ -35,14 +35,7 @@ func (v CustomValue) DeprecatedFetchCompletions(line string, cursor uint32) []pr
 }
 
 func (v CustomValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
+	return v.FetchValue(EmptyValueContextInstance).FetchCompletions(value, cursor)
 }
 
 func (v CustomValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-custom.go
+++ b/server/doc-values/value-custom.go
@@ -30,10 +30,6 @@ func (v CustomValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 	return v.FetchValue(EmptyValueContextInstance).DeprecatedCheckIsValid(value)
 }
 
-func (v CustomValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
-	return v.FetchValue(EmptyValueContextInstance).DeprecatedFetchCompletions(line, cursor)
-}
-
 func (v CustomValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	return v.FetchValue(EmptyValueContextInstance).FetchCompletions(value, cursor)
 }

--- a/server/doc-values/value-custom.go
+++ b/server/doc-values/value-custom.go
@@ -1,6 +1,8 @@
 package docvalues
 
 import (
+	"config-lsp/common"
+
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
@@ -30,6 +32,17 @@ func (v CustomValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 
 func (v CustomValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
 	return v.FetchValue(EmptyValueContextInstance).DeprecatedFetchCompletions(line, cursor)
+}
+
+func (v CustomValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v CustomValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-data-amount-value.go
+++ b/server/doc-values/value-data-amount-value.go
@@ -413,10 +413,6 @@ func (v DataAmountValue) FetchCompletions(value string, cursor common.CursorPosi
 	return utils.AddSubstrToCompletionItems(completions, valueUntilNow)
 }
 
-func (v DataAmountValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
-	return nil
-}
-
 func (v DataAmountValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {
 	///// Calculate the byte amount from the value
 	var byteAmountMessage string

--- a/server/doc-values/value-data-amount-value.go
+++ b/server/doc-values/value-data-amount-value.go
@@ -107,26 +107,6 @@ const (
 	DataAmountValueBase1000 DataAmountValueBase = 1000
 )
 
-// We store the raw value and indexes so that we can later parse them
-// Why don't we parse the value directly?
-// -> Because we want to avoid parsing the value multiple times
-// -> And only a few values will need to be parsed to calculate the byte amount
-type cachedValue struct {
-	rawValue string
-
-	amountStart int
-	amountEnd   int
-
-	decimalStart int
-	decimalEnd   int
-
-	unitStart int
-	unitEnd   int
-
-	suffixStart int
-	suffixEnd   int
-}
-
 type DataAmountValue struct {
 	// The rune set that is allowed for this value.
 	// Valid options are:

--- a/server/doc-values/value-data-amount-value.go
+++ b/server/doc-values/value-data-amount-value.go
@@ -4,6 +4,7 @@ import (
 	"config-lsp/utils"
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -361,7 +362,7 @@ func (v DataAmountValue) DeprecatedFetchCompletions(line string, cursor uint32) 
 		return GenerateBase10Completions(line)
 	}
 
-	lastChar := []rune(line)[cursor]
+	lastChar := []rune(line)[int(math.Max(0, float64(cursor)-1))]
 	isDigit := lastChar >= '0' && lastChar <= '9'
 	isDecimal := lastChar == '.'
 	isUnit := utils.KeyExists(v.AllowedUnits, lastChar)

--- a/server/doc-values/value-data-amount-value.go
+++ b/server/doc-values/value-data-amount-value.go
@@ -1,96 +1,361 @@
 package docvalues
 
 import (
+	"config-lsp/utils"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
-var dataAmountCheckPattern = regexp.MustCompile(`(?i)^(\d+)([KMG])$`)
-
-type InvalidDataAmountError struct{}
-
-func (e InvalidDataAmountError) Error() string {
-	return "Data amount is invalid. It must be in the form of: <number>[K|M|G]"
+var unitDocumentationMap = map[rune]string{
+	'k': "Kilobytes",
+	'm': "Megabytes",
+	'g': "Gigabytes",
+	't': "Terabytes",
+	'e': "Exabytes",
+	'p': "Petabytes",
+	'z': "Zettabytes",
 }
 
-type DataAmountValue struct{}
+// A lax regex pattern to further validate the data amount value.
+var laxPattern = regexp.MustCompile(`(?i)^(?<amount>\d+)(?:\.(?<decimal_amount>\d+))?(?<unit>[a-z])?(?<suffix>b)?$`)
+
+type DataAmountValueBase uint8
+const (
+	DataAmountValueBase1024 DataAmountValueBase = 0
+	DataAmountValueBase1000 DataAmountValueBase = 1
+)
+
+// We store the raw value and indexes so that we can later parse them
+// Why don't we parse the value directly?
+// -> Because we want to avoid parsing the value multiple times
+// -> And only a few values will need to be parsed to calculate the byte amount
+type cachedValue struct {
+	rawValue string
+
+	amountStart int
+	amountEnd int
+
+	decimalStart int
+	decimalEnd int
+
+	unitStart int
+	unitEnd int
+
+	suffixStart int
+	suffixEnd int
+}
+
+type DataAmountValue struct{
+	// The rune set that is allowed for this value.
+	// Valid options are:
+	// - 'k' for kilobytes
+	// - 'm' for megabytes
+	// - 'g' for gigabytes
+	// - 't' for terabytes
+	// - 'e' for exabytes
+	// - 'p' for petabytes
+	// - 'z' for zettabytes
+	// All units should be lowercase.
+	AllowedUnits map[rune]struct{}
+	// Whether to allow `b` or `B` as a suffix for bytes.
+	// Default = false
+	AllowByteSuffix bool
+	// Whether to allow decimal values.
+	// Default = false
+	AllowDecimal bool
+
+	// Set the base to either 1000 or 1024.
+	// Note: Currently only 1024 is supported
+	// Default = 1024
+	Base DataAmountValueBase
+
+	_cachedValue *cachedValue
+}
+
+func (v DataAmountValue) GetRegexPattern() *regexp.Regexp {
+	unitsAsStr := utils.MapMapToSlice(v.AllowedUnits, func(unit rune, _ struct{}) string {
+		return string(unit)
+	})
+	allowedUnits := strings.Join(unitsAsStr, "|")
+
+	decimalPart := ""
+
+	if v.AllowDecimal {
+		decimalPart = `(\.\d+)?`
+	}
+
+	byteSuffix := ""
+
+	if v.AllowByteSuffix {
+		byteSuffix = "(b|B)?"
+	}
+
+	pattern := fmt.Sprintf(`(?i)^(\d+%s)%s%s$`, allowedUnits, decimalPart, byteSuffix)
+
+	return regexp.MustCompile(pattern)
+}
 
 func (v DataAmountValue) GetTypeDescription() []string {
-	return []string{"Data amount"}
+	description := []string{
+		"Byte amount",
+		"Example: 512, 2K, 1M",
+	}
+
+	allowedUnits := utils.MapMapToSlice(v.AllowedUnits, func(unit rune, _ struct{}) string {
+		return fmt.Sprintf("'%c' (%s)", unit, unitDocumentationMap[unit])
+	})
+
+	description = append(description, fmt.Sprintf("* Allowed units: %s", strings.Join(allowedUnits, ", ")))
+
+	if v.AllowDecimal {
+		description = append(description, "* Decimal values are allowed (e.g. 1.5K)")
+	} else {
+		description = append(description, "* Decimal values are not allowed")
+	}
+
+	if v.AllowByteSuffix {
+		description = append(description, "* Byte suffix is allowed (b or B)")
+	} else {
+		description = append(description, "* Byte suffix is not allowed")
+	}
+
+	if v.Base == DataAmountValueBase1024 {
+		description = append(description, "* Base `1024` is used (e.g. 1K = 1024 bytes)")
+	} else {
+		description = append(description, "* Base `1000` is used (e.g. 1K = 1000 bytes)")
+	}
+
+	return description
 }
 
-func (v DataAmountValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
-	if !dataAmountCheckPattern.MatchString(value) {
+func (v *DataAmountValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
+	v._cachedValue = nil
+
+	match := laxPattern.FindStringSubmatchIndex(value)
+
+	if len(match) == 0 {
 		return []*InvalidValue{
 			{
-				Err:   InvalidDataAmountError{},
+				Err:   errors.New("Invalid numeric value"),
 				Start: 0,
 				End:   uint32(len(value)),
 			},
 		}
 	}
 
+	amountStart := match[2]
+	amountEnd := match[3]
+	decimalStart := match[4]
+	decimalEnd := match[5]
+	unitStart := match[6]
+	unitEnd := match[7]
+	suffixStart := match[8]
+	suffixEnd := match[9]
+
+	if amountStart == -1 || amountEnd == -1 {
+		return []*InvalidValue{
+			{
+				Err:   errors.New("Amount is missing"),
+				Start: uint32(amountStart),
+				End:   uint32(amountEnd),
+			},
+		}
+	}
+	if unitStart == -1 && unitEnd != -1 {
+		return []*InvalidValue{
+			{
+				Err:   errors.New("Unit is missing"),
+				Start: uint32(unitStart),
+				End:   uint32(unitEnd),
+			},
+		}
+	}
+
+	unit := rune(value[unitStart])
+	if !utils.KeyExists(v.AllowedUnits, unit) {
+		allowedUnitsString := strings.Join(utils.MapMapToSlice(v.AllowedUnits, func(unit rune, _ struct{}) string {
+			return string(unit)
+		}), ", ")
+		return []*InvalidValue{
+			{
+				Err:   fmt.Errorf("Unit '%c' is not allowed; It must be one of: %s", unit, allowedUnitsString),
+				Start: uint32(unitStart),
+				End:   uint32(unitEnd),
+			},
+		}
+	}
+
+	if !v.AllowByteSuffix && suffixStart != -1 && suffixEnd != -1 {
+		return []*InvalidValue{
+			{
+				Err:   errors.New("Byte suffix is not allowed"),
+				Start: uint32(suffixStart),
+				End:   uint32(suffixEnd),
+			},
+		}
+	}
+
+	if !v.AllowDecimal && decimalStart != -1 && decimalEnd != -1 {
+		return []*InvalidValue{
+			{
+				Err:   errors.New("Decimal part is not allowed"),
+				Start: uint32(decimalStart),
+				End:   uint32(decimalEnd),
+			},
+		}
+	}
+
+	// Validation done, store cached value
+	v._cachedValue = &cachedValue{
+		rawValue: value,
+		amountStart: amountStart,
+		amountEnd: amountEnd,
+		decimalStart: decimalStart,
+		decimalEnd: decimalEnd,
+		unitStart: unitStart,
+		unitEnd: unitEnd,
+		suffixStart: suffixStart,
+		suffixEnd: suffixEnd,
+	}
+
 	return nil
 }
 
-func calculateLineToKilobyte(value string, unit string) string {
-	val, err := strconv.Atoi(value)
+func (v DataAmountValue) generateUnitSuggestions() []protocol.CompletionItem {
+	units := make([]protocol.CompletionItem, 0)
+	completionKind := protocol.CompletionItemKindUnit
 
-	if err != nil {
-		return "<unknown>"
+	for unit := range v.AllowedUnits {
+		unitStr := string(unit)
+
+		units = append(units, protocol.CompletionItem{
+			Label:         unitStr,
+			Kind:          &completionKind,
+			Documentation: unitDocumentationMap[unit],
+		})
 	}
 
-	switch unit {
-	case "K":
-		return strconv.Itoa(val)
-	case "M":
-		return strconv.Itoa(val * 1000)
-	case "G":
-		return strconv.Itoa(val * 1000 * 1000)
-	default:
-		return "<unknown>"
-	}
+	return units
 }
 
 func (v DataAmountValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
 	completions := make([]protocol.CompletionItem, 0)
 
-	if line != "" && !dataAmountCheckPattern.MatchString(line) {
-		kind := protocol.CompletionItemKindValue
-
-		completions = append(
-			completions,
-			protocol.CompletionItem{
-				Label:         line + "K",
-				Kind:          &kind,
-				Documentation: line + " kilobytes",
-			},
-			protocol.CompletionItem{
-				Label:         line + "M",
-				Kind:          &kind,
-				Documentation: fmt.Sprintf("%s megabytes (%s kilobytes)", line, calculateLineToKilobyte(line, "M")),
-			},
-			protocol.CompletionItem{
-				Label:         line + "G",
-				Kind:          &kind,
-				Documentation: fmt.Sprintf("%s gigabytes (%s kilobytes)", line, calculateLineToKilobyte(line, "G")),
-			},
-		)
+	if line == "" {
+		return GenerateBase10Completions(line)
 	}
 
-	if line == "" || isJustDigitsPattern.MatchString(line) {
-		completions = append(
-			completions,
-			GenerateBase10Completions(line)...,
-		)
+	lastChar := []rune(line)[cursor]
+	isDigit := lastChar >= '0' && lastChar <= '9'
+	isDecimal := lastChar == '.'
+	isUnit := utils.KeyExists(v.AllowedUnits, lastChar)
+
+	lineUntilNow := line[:cursor]
+
+	if isDigit {
+		// Possible scenarios:
+		// `5` - suggest unit and decimal point
+		// `5.5` - suggest unit
+
+		// Suggest unit
+		completions = append(completions, v.generateUnitSuggestions()...)
+
+		if v.AllowDecimal && !strings.Contains(lineUntilNow, ".") {
+			kind := protocol.CompletionItemKindValue
+			completions = append(completions, protocol.CompletionItem{
+				Label:         ".",
+				Kind:          &kind,
+				Documentation: "Decimal point",
+			})
+		}
+	} else 
+
+	if isDecimal && v.AllowDecimal {
+		// Possible scenarios:
+		// `5.` - suggest numbers
+
+		completions = append(completions, GenerateBase10Completions(line)...)
+	} else 
+
+	if isUnit && utils.KeyExists(v.AllowedUnits, lastChar) && v.AllowByteSuffix {
+		// Possible scenarios:
+		// `5K` - suggest byte suffix
+		// `5M` - suggest byte suffix
+		// `5G` - suggest byte suffix
+
+		kind := protocol.CompletionItemKindUnit
+		completions = append(completions, protocol.CompletionItem{
+			Label:         "b",
+			Kind:          &kind,
+			Documentation: "Bit suffix",
+		})
+		completions = append(completions, protocol.CompletionItem{
+			Label:         "B",
+			Kind:          &kind,
+			Documentation: "Byte suffix",
+		})
 	}
 
 	return completions
 }
 
 func (v DataAmountValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {
-	return []string{}
+	///// Calculate the byte amount from the value
+	var byteAmountMessage string
+
+	if v._cachedValue != nil {
+		// Parse float
+		rawAmount := v._cachedValue.rawValue[v._cachedValue.amountStart:v._cachedValue.amountEnd]
+
+		if v._cachedValue.decimalStart != -1 {
+			rawAmount += "." + v._cachedValue.rawValue[v._cachedValue.decimalStart:v._cachedValue.decimalEnd]
+		}
+
+		amount, err := strconv.ParseFloat(rawAmount, 64)
+		unit := rune(v._cachedValue.rawValue[v._cachedValue.unitStart])
+
+		var suffix string
+
+		if v._cachedValue.suffixStart != -1 {
+			suffix = v._cachedValue.rawValue[v._cachedValue.suffixStart:v._cachedValue.suffixEnd]
+		} else {
+			suffix = ""
+		}
+
+		var base uint64
+
+		if v.Base == DataAmountValueBase1024 {
+			base = uint64(1024)
+		} else {
+			base = uint64(1000)
+		}
+
+		if err == nil {
+			byteAmount, err := utils.CalculateNumericValueToByte(
+				amount,
+				unit,
+				suffix,
+				base,
+			)
+
+			if err == nil {
+				byteAmountMessage = fmt.Sprintf("%s = %d bytes", rawAmount, byteAmount)
+			}
+		}
+	}
+
+	messages := []string{
+		"Numeric value representing a data amount",
+	}
+
+	if byteAmountMessage != "" {
+		messages = append(messages, byteAmountMessage)
+	}
+
+	return messages
 }

--- a/server/doc-values/value-data-amount-value.go
+++ b/server/doc-values/value-data-amount-value.go
@@ -343,7 +343,7 @@ func (v *DataAmountValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 	if v.Validator != nil {
 		// Calculate the byte amount
 		byteAmount, err := v.calculateBytesAmount()
-		
+
 		if err != nil {
 			return []*InvalidValue{
 				{

--- a/server/doc-values/value-data-amount-value.go
+++ b/server/doc-values/value-data-amount-value.go
@@ -164,7 +164,7 @@ type DataAmountValue struct {
 	_cachedValue *cachedValue
 }
 
-func (v DataAmountValue) generateUnitSuggestions() []protocol.CompletionItem {
+func (v *DataAmountValue) generateUnitSuggestions() []protocol.CompletionItem {
 	units := make([]protocol.CompletionItem, 0)
 	completionKind := protocol.CompletionItemKindUnit
 
@@ -181,7 +181,7 @@ func (v DataAmountValue) generateUnitSuggestions() []protocol.CompletionItem {
 	return units
 }
 
-func (v DataAmountValue) calculateBytesAmount() (uint64, error) {
+func (v *DataAmountValue) calculateBytesAmount() (uint64, error) {
 	if v._cachedValue == nil {
 		return 0, errors.New("value is not cached, please call DeprecatedCheckIsValid first")
 	}
@@ -235,7 +235,7 @@ func (v DataAmountValue) calculateBytesAmount() (uint64, error) {
 	return byteAmount, nil
 }
 
-func (v DataAmountValue) GetTypeDescription() []string {
+func (v *DataAmountValue) GetTypeDescription() []string {
 	description := []string{
 		"Byte amount",
 		"Example: 512, 2K, 1M",
@@ -378,7 +378,7 @@ func (v *DataAmountValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 	return nil
 }
 
-func (v DataAmountValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+func (v *DataAmountValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	completions := make([]protocol.CompletionItem, 0)
 
 	if value == "" {
@@ -435,7 +435,7 @@ func (v DataAmountValue) FetchCompletions(value string, cursor common.CursorPosi
 	return utils.AddSubstrToCompletionItems(completions, valueUntilNow)
 }
 
-func (v DataAmountValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {
+func (v *DataAmountValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {
 	///// Calculate the byte amount from the value
 	var byteAmountMessage string
 	bytesAmount, err := v.calculateBytesAmount()

--- a/server/doc-values/value-data-amount-value_test.go
+++ b/server/doc-values/value-data-amount-value_test.go
@@ -232,7 +232,7 @@ func TestDAEmptyCompletions(t *testing.T) {
 		Base: DataAmountValueBase1024,
 	}
 
-	completions := value.DeprecatedFetchCompletions("", 0)
+	completions := value.FetchCompletions("", 0)
 
 	if len(completions) != 10 {
 		t.Errorf("Expected no completions, got: %v", completions)
@@ -249,9 +249,9 @@ func TestDACompletionsWithValidInput(t *testing.T) {
 		Base: DataAmountValueBase1024,
 	}
 
-	completions := value.DeprecatedFetchCompletions("1", 1)
+	completions := value.FetchCompletions("1", 1)
 
-	if len(completions) == 0 {
+	if len(completions) != 3 {
 		t.Error("Expected completions, got none")
 	}
 }
@@ -266,7 +266,7 @@ func TestDACompletionsAtEnd(t *testing.T) {
 		Base: DataAmountValueBase1024,
 	}
 
-	completions := value.DeprecatedFetchCompletions("1k", 2)
+	completions := value.FetchCompletions("1k", 2)
 
 	if len(completions) != 0 {
 		t.Error("Expected completions, got none")
@@ -284,7 +284,7 @@ func TestDACompletionsNoDecimal(t *testing.T) {
 		AllowDecimal: false,
 	}
 
-	completions := value.DeprecatedFetchCompletions("1.5", 2)
+	completions := value.FetchCompletions("1.5", 2)
 
 	if len(completions) != 0 {
 		t.Error("Expected no completions, got some")
@@ -302,7 +302,7 @@ func TestDaCompletionsDecimal(t *testing.T) {
 		AllowDecimal: true,
 	}
 
-	completions := value.DeprecatedFetchCompletions("1.5", 2)
+	completions := value.FetchCompletions("1.5", 2)
 
 	if len(completions) == 0 {
 		t.Error("Expected completions, got none")

--- a/server/doc-values/value-data-amount-value_test.go
+++ b/server/doc-values/value-data-amount-value_test.go
@@ -191,4 +191,3 @@ func TestDAParseInvalidExampleNotAllowedUnit(t *testing.T) {
 	print(value.GetTypeDescription())
 	print(value.DeprecatedFetchHoverInfo("1.5t", 0))
 }
-

--- a/server/doc-values/value-data-amount-value_test.go
+++ b/server/doc-values/value-data-amount-value_test.go
@@ -21,7 +21,7 @@ func TestDAParseValidExample1(t *testing.T) {
 	print(value.GetTypeDescription())
 	print(value.DeprecatedFetchHoverInfo("1k", 0))
 
-	bytesAmount, err := value.calculateBytesAmount()
+	bytesAmount, err := value.calculateBytesAmount("1k")
 
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)
@@ -29,6 +29,33 @@ func TestDAParseValidExample1(t *testing.T) {
 
 	if bytesAmount != 1024 {
 		t.Errorf("Expected 1024 bytes, got: %d", bytesAmount)
+	}
+}
+
+func TestDA1GExample(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		Base: DataAmountValueBase1024,
+	}
+
+	errs := value.DeprecatedCheckIsValid("1g")
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+
+	bytesAmount, err := value.calculateBytesAmount("1g")
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if bytesAmount != 1073741824 {
+		t.Errorf("Expected 1073741824 bytes, got: %d", bytesAmount)
 	}
 }
 
@@ -52,7 +79,7 @@ func TestDAParseValidExample2(t *testing.T) {
 	print(value.GetTypeDescription())
 	print(value.DeprecatedFetchHoverInfo("1.5k", 0))
 
-	bytesAmount, err := value.calculateBytesAmount()
+	bytesAmount, err := value.calculateBytesAmount("1.5k")
 
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)
@@ -84,7 +111,7 @@ func TestDAParseValidExampleByteSuffix(t *testing.T) {
 	print(value.GetTypeDescription())
 	print(value.DeprecatedFetchHoverInfo("1.5kB", 0))
 
-	byteAmount, err := value.calculateBytesAmount()
+	byteAmount, err := value.calculateBytesAmount("1.5kB")
 
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)
@@ -112,19 +139,6 @@ func TestDAParseValidExampleBitSuffix(t *testing.T) {
 	if len(errs) != 0 {
 		t.Errorf("Expected no errors, got: %v", errs)
 	}
-
-	print(value.GetTypeDescription())
-	print(value.DeprecatedFetchHoverInfo("1.5t", 0))
-
-	byteAmount, err := value.calculateBytesAmount()
-
-	if err != nil {
-		t.Errorf("Expected no error, got: %v", err)
-	}
-
-	if byteAmount != 192 {
-		t.Errorf("Expected 192 bytes, got: %d", byteAmount)
-	}
 }
 
 func TestDAParseValidExampleNoSuffix(t *testing.T) {
@@ -146,7 +160,7 @@ func TestDAParseValidExampleNoSuffix(t *testing.T) {
 	print(value.GetTypeDescription())
 	print(value.DeprecatedFetchHoverInfo("1024", 0))
 
-	bytesAmount, err := value.calculateBytesAmount()
+	bytesAmount, err := value.calculateBytesAmount("1024")
 
 	if err != nil {
 		t.Errorf("Expected no error, got: %v", err)

--- a/server/doc-values/value-data-amount-value_test.go
+++ b/server/doc-values/value-data-amount-value_test.go
@@ -82,7 +82,7 @@ func TestDAParseValidExampleByteSuffix(t *testing.T) {
 	}
 
 	print(value.GetTypeDescription())
-	print(value.DeprecatedFetchHoverInfo("1.5t", 0))
+	print(value.DeprecatedFetchHoverInfo("1.5kB", 0))
 
 	byteAmount, err := value.calculateBytesAmount()
 

--- a/server/doc-values/value-data-amount-value_test.go
+++ b/server/doc-values/value-data-amount-value_test.go
@@ -235,7 +235,7 @@ func TestDAEmptyCompletions(t *testing.T) {
 	completions := value.FetchCompletions("", 0)
 
 	if len(completions) != 10 {
-		t.Errorf("Expected no completions, got: %v", completions)
+		t.Errorf("Expected 10 completions, got: %v", completions)
 	}
 }
 
@@ -269,7 +269,7 @@ func TestDACompletionsAtEnd(t *testing.T) {
 	completions := value.FetchCompletions("1k", 2)
 
 	if len(completions) != 0 {
-		t.Error("Expected completions, got none")
+		t.Error("Expected no completions, got none")
 	}
 }
 

--- a/server/doc-values/value-data-amount-value_test.go
+++ b/server/doc-values/value-data-amount-value_test.go
@@ -1,0 +1,194 @@
+package docvalues
+
+import "testing"
+
+func TestDAParseValidExample1(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		Base: DataAmountValueBase1024,
+	}
+
+	errs := value.DeprecatedCheckIsValid("1k")
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+
+	print(value.GetTypeDescription())
+	print(value.DeprecatedFetchHoverInfo("1k", 0))
+
+	bytesAmount, err := value.calculateBytesAmount()
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if bytesAmount != 1024 {
+		t.Errorf("Expected 1024 bytes, got: %d", bytesAmount)
+	}
+}
+
+func TestDAParseValidExample2(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		AllowDecimal: true,
+		Base:         DataAmountValueBase1024,
+	}
+
+	errs := value.DeprecatedCheckIsValid("1.5k")
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+
+	print(value.GetTypeDescription())
+	print(value.DeprecatedFetchHoverInfo("1.5k", 0))
+
+	bytesAmount, err := value.calculateBytesAmount()
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if bytesAmount != 1536 {
+		t.Errorf("Expected 1536 bytes, got: %d", bytesAmount)
+	}
+}
+
+func TestDAParseValidExampleByteSuffix(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		AllowByteSuffix: true,
+		AllowDecimal:    true,
+		Base:            DataAmountValueBase1024,
+	}
+
+	errs := value.DeprecatedCheckIsValid("1.5kB")
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+
+	print(value.GetTypeDescription())
+	print(value.DeprecatedFetchHoverInfo("1.5t", 0))
+
+	byteAmount, err := value.calculateBytesAmount()
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if byteAmount != 1536 {
+		t.Errorf("Expected 1536 bytes, got: %d", byteAmount)
+	}
+}
+
+func TestDAParseValidExampleBitSuffix(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		AllowByteSuffix: true,
+		AllowDecimal:    true,
+		Base:            DataAmountValueBase1024,
+	}
+
+	errs := value.DeprecatedCheckIsValid("1.5kb")
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+
+	print(value.GetTypeDescription())
+	print(value.DeprecatedFetchHoverInfo("1.5t", 0))
+
+	byteAmount, err := value.calculateBytesAmount()
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if byteAmount != 192 {
+		t.Errorf("Expected 192 bytes, got: %d", byteAmount)
+	}
+}
+
+func TestDAParseInvalidExample1(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		Base: DataAmountValueBase1024,
+	}
+
+	errs := value.DeprecatedCheckIsValid("1x")
+
+	if len(errs) == 0 {
+		t.Error("Expected errors, got none")
+	}
+
+	print(value.GetTypeDescription())
+	print(value.DeprecatedFetchHoverInfo("1x", 0))
+}
+
+func TestDAParseInvalidExampleNoUnit(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		Base: DataAmountValueBase1024,
+	}
+
+	errs := value.DeprecatedCheckIsValid("1.5t")
+
+	if len(errs) == 0 {
+		t.Error("Expected errors, got none")
+	} else {
+		print(errs[0].Err.Error())
+	}
+
+	print(value.GetTypeDescription())
+	print(value.DeprecatedFetchHoverInfo("1.5t", 0))
+}
+
+func TestDAParseInvalidExampleNotAllowedUnit(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		AllowDecimal: false,
+		Base:         DataAmountValueBase1024,
+	}
+
+	errs := value.DeprecatedCheckIsValid("1.5t")
+
+	if len(errs) == 0 {
+		t.Error("Expected errors, got none")
+	} else {
+		print(errs[0].Err.Error())
+	}
+
+	print(value.GetTypeDescription())
+	print(value.DeprecatedFetchHoverInfo("1.5t", 0))
+}
+

--- a/server/doc-values/value-data-amount-value_test.go
+++ b/server/doc-values/value-data-amount-value_test.go
@@ -127,6 +127,36 @@ func TestDAParseValidExampleBitSuffix(t *testing.T) {
 	}
 }
 
+func TestDAParseValidExampleNoSuffix(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		Base: DataAmountValueBase1024,
+	}
+
+	errs := value.DeprecatedCheckIsValid("1024")
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+
+	print(value.GetTypeDescription())
+	print(value.DeprecatedFetchHoverInfo("1024", 0))
+
+	bytesAmount, err := value.calculateBytesAmount()
+
+	if err != nil {
+		t.Errorf("Expected no error, got: %v", err)
+	}
+
+	if bytesAmount != 1024 {
+		t.Errorf("Expected 1024 bytes, got: %d", bytesAmount)
+	}
+}
+
 func TestDAParseInvalidExample1(t *testing.T) {
 	value := DataAmountValue{
 		AllowedUnits: map[rune]struct{}{

--- a/server/doc-values/value-data-amount-value_test.go
+++ b/server/doc-values/value-data-amount-value_test.go
@@ -221,3 +221,90 @@ func TestDAParseInvalidExampleNotAllowedUnit(t *testing.T) {
 	print(value.GetTypeDescription())
 	print(value.DeprecatedFetchHoverInfo("1.5t", 0))
 }
+
+func TestDAEmptyCompletions(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		Base: DataAmountValueBase1024,
+	}
+
+	completions := value.DeprecatedFetchCompletions("", 0)
+
+	if len(completions) != 10 {
+		t.Errorf("Expected no completions, got: %v", completions)
+	}
+}
+
+func TestDACompletionsWithValidInput(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		Base: DataAmountValueBase1024,
+	}
+
+	completions := value.DeprecatedFetchCompletions("1", 1)
+
+	if len(completions) == 0 {
+		t.Error("Expected completions, got none")
+	}
+}
+
+func TestDACompletionsAtEnd(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		Base: DataAmountValueBase1024,
+	}
+
+	completions := value.DeprecatedFetchCompletions("1k", 2)
+
+	if len(completions) != 0 {
+		t.Error("Expected completions, got none")
+	}
+}
+
+func TestDACompletionsNoDecimal(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		Base:         DataAmountValueBase1024,
+		AllowDecimal: false,
+	}
+
+	completions := value.DeprecatedFetchCompletions("1.5", 2)
+
+	if len(completions) != 0 {
+		t.Error("Expected no completions, got some")
+	}
+}
+
+func TestDaCompletionsDecimal(t *testing.T) {
+	value := DataAmountValue{
+		AllowedUnits: map[rune]struct{}{
+			'k': {},
+			'm': {},
+			'g': {},
+		},
+		Base:         DataAmountValueBase1024,
+		AllowDecimal: true,
+	}
+
+	completions := value.DeprecatedFetchCompletions("1.5", 2)
+
+	if len(completions) == 0 {
+		t.Error("Expected completions, got none")
+	}
+}

--- a/server/doc-values/value-documentation.go
+++ b/server/doc-values/value-documentation.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"strings"
 
 	protocol "github.com/tliron/glsp/protocol_3_16"
@@ -21,6 +22,17 @@ func (v DocumentationValue) DeprecatedCheckIsValid(value string) []*InvalidValue
 
 func (v DocumentationValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
 	return v.Value.DeprecatedFetchCompletions(line, cursor)
+}
+
+func (v DocumentationValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v DocumentationValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-documentation.go
+++ b/server/doc-values/value-documentation.go
@@ -25,14 +25,7 @@ func (v DocumentationValue) DeprecatedFetchCompletions(line string, cursor uint3
 }
 
 func (v DocumentationValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
+	return v.Value.FetchCompletions(value, cursor)
 }
 
 func (v DocumentationValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-documentation.go
+++ b/server/doc-values/value-documentation.go
@@ -20,10 +20,6 @@ func (v DocumentationValue) DeprecatedCheckIsValid(value string) []*InvalidValue
 	return v.Value.DeprecatedCheckIsValid(value)
 }
 
-func (v DocumentationValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
-	return v.Value.DeprecatedFetchCompletions(line, cursor)
-}
-
 func (v DocumentationValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	return v.Value.FetchCompletions(value, cursor)
 }

--- a/server/doc-values/value-enum.go
+++ b/server/doc-values/value-enum.go
@@ -102,7 +102,7 @@ func (v EnumValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 		},
 	}
 }
-func (v EnumValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
+func (v EnumValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	completions := make([]protocol.CompletionItem, len(v.Values))
 
 	for index, value := range v.Values {
@@ -118,17 +118,6 @@ func (v EnumValue) DeprecatedFetchCompletions(line string, cursor uint32) []prot
 	}
 
 	return completions
-}
-
-func (v EnumValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
 }
 
 func (v EnumValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-enum.go
+++ b/server/doc-values/value-enum.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"config-lsp/utils"
 	"fmt"
 	"strings"
@@ -118,6 +119,18 @@ func (v EnumValue) DeprecatedFetchCompletions(line string, cursor uint32) []prot
 
 	return completions
 }
+
+func (v EnumValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
+}
+
 func (v EnumValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {
 	for _, value := range v.Values {
 		if value.InsertText == line {

--- a/server/doc-values/value-enum.go
+++ b/server/doc-values/value-enum.go
@@ -9,12 +9,12 @@ import (
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
-type ValueNotInEnumError struct {
+type ValueEnumValNotInEnumsError struct {
 	AvailableValues []string
 	ProvidedValue   string
 }
 
-func (e ValueNotInEnumError) Error() string {
+func (e ValueEnumValNotInEnumsError) Error() string {
 	if len(e.AvailableValues) <= 6 {
 		return fmt.Sprintf("This value is not valid. Select one from: %s", strings.Join(e.AvailableValues, ","))
 	} else {
@@ -93,7 +93,7 @@ func (v EnumValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 
 	return []*InvalidValue{
 		{
-			Err: ValueNotInEnumError{
+			Err: ValueEnumValNotInEnumsError{
 				ProvidedValue:   value,
 				AvailableValues: utils.Map(v.Values, func(value EnumString) string { return value.InsertText }),
 			},

--- a/server/doc-values/value-gid.go
+++ b/server/doc-values/value-gid.go
@@ -90,7 +90,7 @@ var defaultGIDsExplanation = []EnumString{
 	},
 }
 
-func (v GIDValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
+func (v GIDValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	infos, err := common.FetchGroupInfo()
 
 	if err != nil {
@@ -127,17 +127,6 @@ func (v GIDValue) DeprecatedFetchCompletions(line string, cursor uint32) []proto
 	}
 
 	return completions
-}
-
-func (v GIDValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
 }
 
 func (v GIDValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-gid.go
+++ b/server/doc-values/value-gid.go
@@ -128,6 +128,18 @@ func (v GIDValue) DeprecatedFetchCompletions(line string, cursor uint32) []proto
 
 	return completions
 }
+
+func (v GIDValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
+}
+
 func (v GIDValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {
 	uid, err := strconv.Atoi(line)
 

--- a/server/doc-values/value-ip-address.go
+++ b/server/doc-values/value-ip-address.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"config-lsp/utils"
 	"fmt"
 	net "net/netip"
@@ -182,6 +183,17 @@ func (v IPAddressValue) DeprecatedFetchCompletions(line string, cursor uint32) [
 	}
 
 	return []protocol.CompletionItem{}
+}
+
+func (v IPAddressValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v IPAddressValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-ip-address.go
+++ b/server/doc-values/value-ip-address.go
@@ -152,7 +152,7 @@ func (v IPAddressValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 	}
 }
 
-func (v IPAddressValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
+func (v IPAddressValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	if v.AllowedIPs != nil && len(*v.AllowedIPs) != 0 {
 		kind := protocol.CompletionItemKindValue
 
@@ -165,9 +165,9 @@ func (v IPAddressValue) DeprecatedFetchCompletions(line string, cursor uint32) [
 	}
 
 	if v.AllowRange {
-		slashIndex := strings.LastIndex(line, "/")
+		slashIndex := strings.LastIndex(value, "/")
 
-		if slashIndex > -1 && cursor >= uint32(slashIndex) {
+		if slashIndex > -1 && cursor.IsAfterIndexPosition(common.IndexPosition(slashIndex)) {
 			completions := make([]protocol.CompletionItem, 33)
 
 			for i := 0; i < len(completions); i++ {
@@ -183,17 +183,6 @@ func (v IPAddressValue) DeprecatedFetchCompletions(line string, cursor uint32) [
 	}
 
 	return []protocol.CompletionItem{}
-}
-
-func (v IPAddressValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
 }
 
 func (v IPAddressValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-key-enum-assignment.go
+++ b/server/doc-values/value-key-enum-assignment.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"config-lsp/utils"
 	"fmt"
 	"strings"
@@ -163,6 +164,17 @@ func (v KeyEnumAssignmentValue) getValueAtCursor(line string, cursor uint32) (st
 
 	// No separator, so we can just return the whole line
 	return line, &selected, cursor
+}
+
+func (v KeyEnumAssignmentValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v KeyEnumAssignmentValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {

--- a/server/doc-values/value-key-enum-assignment.go
+++ b/server/doc-values/value-key-enum-assignment.go
@@ -220,10 +220,6 @@ func (v KeyEnumAssignmentValue) FetchCompletions(value string, cursor common.Cur
 	}
 }
 
-func (v KeyEnumAssignmentValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
-	return nil
-}
-
 func (v KeyEnumAssignmentValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {
 	if len(v.DeprecatedCheckIsValid(line)) != 0 {
 		return []string{}

--- a/server/doc-values/value-key-enum-assignment.go
+++ b/server/doc-values/value-key-enum-assignment.go
@@ -209,7 +209,7 @@ func (v KeyEnumAssignmentValue) FetchCompletions(value string, cursor common.Cur
 			return nil
 		}
 
-		start := uint32(foundPosition + len(v.Separator))
+		start := foundPosition + len(v.Separator)
 		remainingValue := value[start:]
 		remainingCursor := cursor.ShiftHorizontal(-start)
 

--- a/server/doc-values/value-key-enum-assignment.go
+++ b/server/doc-values/value-key-enum-assignment.go
@@ -100,7 +100,7 @@ func (v KeyEnumAssignmentValue) DeprecatedCheckIsValid(value string) []*InvalidV
 	if !found {
 		return []*InvalidValue{
 			{
-				Err: ValueNotInEnumError{
+				Err: ValueEnumValNotInEnumsError{
 					AvailableValues: utils.Map(utils.KeysOfMap(v.Values), func(key EnumString) string { return key.InsertText }),
 					ProvidedValue:   parts[0],
 				},

--- a/server/doc-values/value-key-enum-assignment_test.go
+++ b/server/doc-values/value-key-enum-assignment_test.go
@@ -1,0 +1,88 @@
+package docvalues
+
+import "testing"
+
+func TestKEAValidExample1(t *testing.T) {
+	value := KeyEnumAssignmentValue{
+		Values: map[EnumString]DeprecatedValue{
+			CreateEnumString("burger"): NumberValue{},
+			CreateEnumString("pizza"):  StringValue{},
+		},
+		Separator: "=",
+	}
+
+	errs := value.DeprecatedCheckIsValid("burger=12")
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+}
+
+func TestKEAValidExampleValueOptional(t *testing.T) {
+	value := KeyEnumAssignmentValue{
+		Values: map[EnumString]DeprecatedValue{
+			CreateEnumString("burger"): NumberValue{},
+			CreateEnumString("pizza"):  StringValue{},
+		},
+		Separator:       "=",
+		ValueIsOptional: true,
+	}
+
+	errs := value.DeprecatedCheckIsValid("burger")
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+}
+
+func TestKEAValidExample2(t *testing.T) {
+	value := KeyEnumAssignmentValue{
+		Values: map[EnumString]DeprecatedValue{
+			CreateEnumString("burger"): NumberValue{},
+			CreateEnumString("pizza"):  StringValue{},
+		},
+		Separator: "=",
+	}
+
+	errs := value.DeprecatedCheckIsValid("pizza=cheese")
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+}
+
+func TestKEAInvalidExample1(t *testing.T) {
+	value := KeyEnumAssignmentValue{
+		Values: map[EnumString]DeprecatedValue{
+			CreateEnumString("burger"): NumberValue{},
+			CreateEnumString("pizza"):  StringValue{},
+		},
+		Separator: "=",
+	}
+
+	errs := value.DeprecatedCheckIsValid("burger=cheese")
+
+	if len(errs) == 0 {
+		t.Error("Expected errors, got none")
+	} else {
+		t.Logf("Got expected errors: %v", errs)
+	}
+}
+
+func TestKEAInvalidExampleEnumDoesNotExist(t *testing.T) {
+	value := KeyEnumAssignmentValue{
+		Values: map[EnumString]DeprecatedValue{
+			CreateEnumString("burger"): NumberValue{},
+			CreateEnumString("pizza"):  StringValue{},
+		},
+		Separator: "=",
+	}
+
+	errs := value.DeprecatedCheckIsValid("salad=12")
+
+	if len(errs) == 0 {
+		t.Error("Expected errors, got none")
+	} else {
+		t.Logf("Got expected errors: %v", errs)
+	}
+}

--- a/server/doc-values/value-key-value-assignment.go
+++ b/server/doc-values/value-key-value-assignment.go
@@ -175,14 +175,11 @@ func (v KeyValueAssignmentValue) FetchCompletions(value string, cursor common.Cu
 }
 
 func (v KeyValueAssignmentValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {
-	println("aaahhh")
 	if len(v.DeprecatedCheckIsValid(line)) != 0 {
-		println("Invalid key-value assignment, returning empty hover info")
 		return []string{}
 	}
 
 	value, selected, cursor := v.getValueAtCursor(line, cursor)
-	println(fmt.Sprintf("Value: %s, Selected: %v, Cursor: %d", value, selected, cursor))
 
 	if selected == nil {
 		return []string{}

--- a/server/doc-values/value-key-value-assignment.go
+++ b/server/doc-values/value-key-value-assignment.go
@@ -104,10 +104,6 @@ func (v KeyValueAssignmentValue) DeprecatedCheckIsValid(value string) []*Invalid
 	return nil
 }
 
-func (v KeyValueAssignmentValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
-	return nil
-}
-
 func (v KeyValueAssignmentValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	if value == "" {
 		return v.Key.FetchCompletions(value, 0)

--- a/server/doc-values/value-key-value-assignment.go
+++ b/server/doc-values/value-key-value-assignment.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"config-lsp/utils"
 	"fmt"
 	"strings"
@@ -124,6 +125,17 @@ func (v KeyValueAssignmentValue) DeprecatedFetchCompletions(line string, cursor 
 	} else {
 		return v.Key.DeprecatedFetchCompletions(line, cursor)
 	}
+}
+
+func (v KeyValueAssignmentValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v KeyValueAssignmentValue) getValueAtCursor(line string, cursor uint32) (string, *selectedValue, uint32) {

--- a/server/doc-values/value-key-value-assignment.go
+++ b/server/doc-values/value-key-value-assignment.go
@@ -164,7 +164,7 @@ func (v KeyValueAssignmentValue) FetchCompletions(value string, cursor common.Cu
 	if found {
 		selectedKey := value[:uint32(foundPosition)]
 
-		start := uint32(foundPosition + len(v.Separator))
+		start := foundPosition + len(v.Separator)
 		remainingValue := value[start:]
 		remainingCursor := cursor.ShiftHorizontal(-start)
 

--- a/server/doc-values/value-key-value-assignment_test.go
+++ b/server/doc-values/value-key-value-assignment_test.go
@@ -14,4 +14,29 @@ func TestKVAValidExample1(t *testing.T) {
 	if len(errs) != 0 {
 		t.Errorf("Expected no errors, got: %v", errs)
 	}
+
+	val1, select1, cursor1 := value.getValueAtCursor("key=123", 0)
+	if !(val1 == "key" && *select1 == keySelected && cursor1 == 0) {
+		t.Errorf("Expected (key, keySelected, 0), got (%s, %v, %d)", val1, select1, cursor1)
+	}
+
+	val2, select2, cursor2 := value.getValueAtCursor("key=123", 2)
+	if !(val2 == "key" && *select2 == keySelected && cursor2 == 2) {
+		t.Errorf("Expected (key=123, valueSelected, 2), got (%s, %v, %d)", val2, select2, cursor2)
+	}
+
+	val3, select3, cursor3 := value.getValueAtCursor("key=123", 4)
+	if !(val3 == "123" && *select3 == valueSelected && cursor3 == 0) {
+		t.Errorf("Expected (key=123, valueSelected, 0), got (%s, %v, %d)", val3, select3, cursor3)
+	}
+
+	val4, select4, cursor4 := value.getValueAtCursor("key=123", 6)
+	if !(val4 == "123" && *select4 == valueSelected && cursor4 == 2) {
+		t.Errorf("Expected (key=123, valueSelected, 2), got (%s, %v, %d)", val4, select4, cursor4)
+	}
+
+	val5, select5, cursor5 := value.getValueAtCursor("key=123", 3)
+	if !(val5 == "" && select5 == nil && cursor5 == 0) {
+		t.Errorf("Expected (key=123, nil, 0), got (%s, %v, %d)", val5, select5, cursor5)
+	}
 }

--- a/server/doc-values/value-key-value-assignment_test.go
+++ b/server/doc-values/value-key-value-assignment_test.go
@@ -1,0 +1,17 @@
+package docvalues
+
+import "testing"
+
+func TestKVAValidExample1(t *testing.T) {
+	value := KeyValueAssignmentValue{
+		Key:       StringValue{},
+		Value:     NumberValue{},
+		Separator: "=",
+	}
+
+	errs := value.DeprecatedCheckIsValid("key=123")
+
+	if len(errs) != 0 {
+		t.Errorf("Expected no errors, got: %v", errs)
+	}
+}

--- a/server/doc-values/value-mask-mode.go
+++ b/server/doc-values/value-mask-mode.go
@@ -42,7 +42,7 @@ func (v MaskModeValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 	return []*InvalidValue{}
 }
 
-func (v MaskModeValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
+func (v MaskModeValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	kind := protocol.CompletionItemKindValue
 
 	perm0644 := "0644"
@@ -123,17 +123,6 @@ func (v MaskModeValue) DeprecatedFetchCompletions(line string, cursor uint32) []
 			Kind:          &kind,
 		},
 	}
-}
-
-func (v MaskModeValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
 }
 
 func getMaskRepresentation(digit uint8) string {

--- a/server/doc-values/value-mask-mode.go
+++ b/server/doc-values/value-mask-mode.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"fmt"
 	"regexp"
 
@@ -122,6 +123,17 @@ func (v MaskModeValue) DeprecatedFetchCompletions(line string, cursor uint32) []
 			Kind:          &kind,
 		},
 	}
+}
+
+func (v MaskModeValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func getMaskRepresentation(digit uint8) string {

--- a/server/doc-values/value-number.go
+++ b/server/doc-values/value-number.go
@@ -76,17 +76,6 @@ func (v NumberValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 }
 
 func (v NumberValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
-}
-
-func (v NumberValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
 	return []protocol.CompletionItem{}
 }
 

--- a/server/doc-values/value-number.go
+++ b/server/doc-values/value-number.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"fmt"
 	"strconv"
 
@@ -73,6 +74,18 @@ func (v NumberValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 
 	return nil
 }
+
+func (v NumberValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
+}
+
 func (v NumberValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
 	return []protocol.CompletionItem{}
 }

--- a/server/doc-values/value-or.go
+++ b/server/doc-values/value-or.go
@@ -50,7 +50,8 @@ func (v OrValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 
 	return errors
 }
-func (v OrValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
+
+func (v OrValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	// Check for special cases
 	if len(v.Values) == 2 {
 		switch v.Values[0].(type) {
@@ -61,14 +62,16 @@ func (v OrValue) DeprecatedFetchCompletions(line string, cursor uint32) []protoc
 				// the values of the KeyEnumAssignment
 				keyEnumValue := v.Values[0].(KeyEnumAssignmentValue)
 
+				index := common.DeprecatedImprovedCursorToIndex(cursor, value, 0)
+
 				_, found := utils.FindPreviousCharacter(
-					line,
+					value,
 					keyEnumValue.Separator,
-					int(cursor),
+					int(index),
 				)
 
 				if found {
-					return keyEnumValue.DeprecatedFetchCompletions(line, cursor)
+					return keyEnumValue.FetchCompletions(value, cursor)
 				}
 			}
 		}
@@ -77,21 +80,10 @@ func (v OrValue) DeprecatedFetchCompletions(line string, cursor uint32) []protoc
 	completions := make([]protocol.CompletionItem, 0)
 
 	for _, subValue := range v.Values {
-		completions = append(completions, subValue.DeprecatedFetchCompletions(line, cursor)...)
+		completions = append(completions, subValue.FetchCompletions(value, cursor)...)
 	}
 
 	return completions
-}
-
-func (v OrValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
 }
 
 func (v OrValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-or.go
+++ b/server/doc-values/value-or.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"config-lsp/utils"
 	"strings"
 
@@ -80,6 +81,17 @@ func (v OrValue) DeprecatedFetchCompletions(line string, cursor uint32) []protoc
 	}
 
 	return completions
+}
+
+func (v OrValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v OrValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-path.go
+++ b/server/doc-values/value-path.go
@@ -109,19 +109,8 @@ func (v PathValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 	}}
 }
 
-func (v PathValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
-	return []protocol.CompletionItem{}
-}
-
 func (v PathValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
+	return []protocol.CompletionItem{}
 }
 
 func (v PathValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-path.go
+++ b/server/doc-values/value-path.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"config-lsp/utils"
 	"errors"
 	"strings"
@@ -110,6 +111,17 @@ func (v PathValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 
 func (v PathValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
 	return []protocol.CompletionItem{}
+}
+
+func (v PathValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v PathValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-power-of-two.go
+++ b/server/doc-values/value-power-of-two.go
@@ -61,7 +61,7 @@ func (v PowerOfTwoValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 
 var powers = []int{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536}
 
-func (v PowerOfTwoValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
+func (v PowerOfTwoValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	textFormat := protocol.InsertTextFormatPlainText
 	kind := protocol.CompletionItemKindValue
 
@@ -74,17 +74,6 @@ func (v PowerOfTwoValue) DeprecatedFetchCompletions(line string, cursor uint32) 
 				Kind:             &kind,
 			}
 		},
-	)
-}
-
-func (v PowerOfTwoValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
 	)
 }
 

--- a/server/doc-values/value-power-of-two.go
+++ b/server/doc-values/value-power-of-two.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"config-lsp/utils"
 	"strconv"
 
@@ -73,6 +74,17 @@ func (v PowerOfTwoValue) DeprecatedFetchCompletions(line string, cursor uint32) 
 				Kind:             &kind,
 			}
 		},
+	)
+}
+
+func (v PowerOfTwoValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
 	)
 }
 

--- a/server/doc-values/value-prefix.go
+++ b/server/doc-values/value-prefix.go
@@ -43,14 +43,14 @@ func (v PrefixWithMeaningValue) DeprecatedCheckIsValid(value string) []*InvalidV
 	return v.SubValue.DeprecatedCheckIsValid(value)
 }
 
-func (v PrefixWithMeaningValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
+func (v PrefixWithMeaningValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	textFormat := protocol.InsertTextFormatPlainText
 	kind := protocol.CompletionItemKindText
 
 	// Check if the line starts with a prefix
 	startsWithPrefix := false
 	for _, prefix := range v.Prefixes {
-		if strings.HasPrefix(line, prefix.Prefix) {
+		if strings.HasPrefix(value, prefix.Prefix) {
 			startsWithPrefix = true
 			break
 		}
@@ -68,18 +68,7 @@ func (v PrefixWithMeaningValue) DeprecatedFetchCompletions(line string, cursor u
 		})
 	}
 
-	return append(prefixCompletions, v.SubValue.DeprecatedFetchCompletions(line, cursor)...)
-}
-
-func (v PrefixWithMeaningValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
+	return append(prefixCompletions, v.SubValue.FetchCompletions(value, cursor)...)
 }
 
 func (v PrefixWithMeaningValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-prefix.go
+++ b/server/doc-values/value-prefix.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"config-lsp/utils"
 	"fmt"
 	"strings"
@@ -68,6 +69,17 @@ func (v PrefixWithMeaningValue) DeprecatedFetchCompletions(line string, cursor u
 	}
 
 	return append(prefixCompletions, v.SubValue.DeprecatedFetchCompletions(line, cursor)...)
+}
+
+func (v PrefixWithMeaningValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v PrefixWithMeaningValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-regex.go
+++ b/server/doc-values/value-regex.go
@@ -38,19 +38,8 @@ func (v RegexValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 	return []*InvalidValue{}
 }
 
-func (v RegexValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
-	return []protocol.CompletionItem{}
-}
-
 func (v RegexValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
+	return []protocol.CompletionItem{}
 }
 
 func (v RegexValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-regex.go
+++ b/server/doc-values/value-regex.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"fmt"
 	"regexp"
 
@@ -39,6 +40,17 @@ func (v RegexValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 
 func (v RegexValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
 	return []protocol.CompletionItem{}
+}
+
+func (v RegexValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v RegexValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-string.go
+++ b/server/doc-values/value-string.go
@@ -47,19 +47,8 @@ func (v StringValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 	return nil
 }
 
-func (v StringValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
-	return []protocol.CompletionItem{}
-}
-
 func (v StringValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
+	return []protocol.CompletionItem{}
 }
 
 func (v StringValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-string.go
+++ b/server/doc-values/value-string.go
@@ -1,6 +1,8 @@
 package docvalues
 
 import (
+	"config-lsp/common"
+
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
@@ -47,6 +49,17 @@ func (v StringValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 
 func (v StringValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
 	return []protocol.CompletionItem{}
+}
+
+func (v StringValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v StringValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-suffix.go
+++ b/server/doc-values/value-suffix.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"config-lsp/utils"
 	"fmt"
 	"strings"
@@ -57,6 +58,17 @@ func (v SuffixWithMeaningValue) DeprecatedFetchCompletions(line string, cursor u
 	})
 
 	return append(suffixCompletions, v.SubValue.DeprecatedFetchCompletions(line, cursor)...)
+}
+
+func (v SuffixWithMeaningValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v SuffixWithMeaningValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-suffix.go
+++ b/server/doc-values/value-suffix.go
@@ -44,7 +44,7 @@ func (v SuffixWithMeaningValue) DeprecatedCheckIsValid(value string) []*InvalidV
 	return v.SubValue.DeprecatedCheckIsValid(value)
 }
 
-func (v SuffixWithMeaningValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
+func (v SuffixWithMeaningValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	textFormat := protocol.InsertTextFormatPlainText
 	kind := protocol.CompletionItemKindText
 
@@ -57,18 +57,7 @@ func (v SuffixWithMeaningValue) DeprecatedFetchCompletions(line string, cursor u
 		}
 	})
 
-	return append(suffixCompletions, v.SubValue.DeprecatedFetchCompletions(line, cursor)...)
-}
-
-func (v SuffixWithMeaningValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
+	return append(suffixCompletions, v.SubValue.FetchCompletions(value, cursor)...)
 }
 
 func (v SuffixWithMeaningValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-time-format.go
+++ b/server/doc-values/value-time-format.go
@@ -57,10 +57,10 @@ func calculateInSeconds(value int, unit string) int {
 	}
 }
 
-func (v TimeFormatValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
+func (v TimeFormatValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	completions := make([]protocol.CompletionItem, 0)
 
-	if line != "" && !timeFormatCompletionsPattern.MatchString(line) {
+	if value != "" && !timeFormatCompletionsPattern.MatchString(value) {
 		completions = append(
 			completions,
 			utils.Map(
@@ -77,18 +77,18 @@ func (v TimeFormatValue) DeprecatedFetchCompletions(line string, cursor uint32) 
 					}[unit]
 
 					var detail string
-					value, err := strconv.Atoi(line)
+					numberValue, err := strconv.Atoi(value)
 
 					if err == nil {
 						if unit == "s" {
-							detail = fmt.Sprintf("%d seconds", value)
+							detail = fmt.Sprintf("%d seconds", numberValue)
 						} else {
-							detail = fmt.Sprintf("%d %s (%d seconds)", value, unitName, calculateInSeconds(value, unit))
+							detail = fmt.Sprintf("%d %s (%d seconds)", numberValue, unitName, calculateInSeconds(numberValue, unit))
 						}
 					}
 
 					return protocol.CompletionItem{
-						Label:  line + unit,
+						Label:  value + unit,
 						Kind:   &kind,
 						Detail: &detail,
 					}
@@ -97,25 +97,14 @@ func (v TimeFormatValue) DeprecatedFetchCompletions(line string, cursor uint32) 
 		)
 	}
 
-	if line == "" || isJustDigitsPattern.MatchString(line) {
+	if value == "" || isJustDigitsPattern.MatchString(value) {
 		completions = append(
 			completions,
-			GenerateBase10Completions(line)...,
+			GenerateBase10Completions(value)...,
 		)
 	}
 
 	return completions
-}
-
-func (v TimeFormatValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
 }
 
 func (v TimeFormatValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-time-format.go
+++ b/server/doc-values/value-time-format.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"config-lsp/utils"
 	"fmt"
 	"regexp"
@@ -104,6 +105,17 @@ func (v TimeFormatValue) DeprecatedFetchCompletions(line string, cursor uint32) 
 	}
 
 	return completions
+}
+
+func (v TimeFormatValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v TimeFormatValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-uid.go
+++ b/server/doc-values/value-uid.go
@@ -90,7 +90,7 @@ var defaultUIDsExplanation = []EnumString{
 	},
 }
 
-func (v UIDValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
+func (v UIDValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	infos, err := common.FetchPasswdInfo()
 
 	if err != nil {
@@ -127,17 +127,6 @@ func (v UIDValue) DeprecatedFetchCompletions(line string, cursor uint32) []proto
 	}
 
 	return completions
-}
-
-func (v UIDValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
 }
 
 func (v UIDValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-uid.go
+++ b/server/doc-values/value-uid.go
@@ -129,6 +129,17 @@ func (v UIDValue) DeprecatedFetchCompletions(line string, cursor uint32) []proto
 	return completions
 }
 
+func (v UIDValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
+}
+
 func (v UIDValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {
 	uid, err := strconv.Atoi(line)
 

--- a/server/doc-values/value-umask.go
+++ b/server/doc-values/value-umask.go
@@ -1,6 +1,7 @@
 package docvalues
 
 import (
+	"config-lsp/common"
 	"regexp"
 
 	protocol "github.com/tliron/glsp/protocol_3_16"
@@ -109,6 +110,17 @@ func (v UmaskValue) DeprecatedFetchCompletions(line string, cursor uint32) []pro
 			Kind:          &kind,
 		},
 	}
+}
+
+func (v UmaskValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
+	return v.DeprecatedFetchCompletions(
+		value,
+		common.DeprecatedImprovedCursorToIndex(
+			cursor,
+			value,
+			0,
+		),
+	)
 }
 
 func (v UmaskValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/doc-values/value-umask.go
+++ b/server/doc-values/value-umask.go
@@ -41,7 +41,7 @@ func (v UmaskValue) DeprecatedCheckIsValid(value string) []*InvalidValue {
 	return []*InvalidValue{}
 }
 
-func (v UmaskValue) DeprecatedFetchCompletions(line string, cursor uint32) []protocol.CompletionItem {
+func (v UmaskValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
 	kind := protocol.CompletionItemKindValue
 
 	return []protocol.CompletionItem{
@@ -110,17 +110,6 @@ func (v UmaskValue) DeprecatedFetchCompletions(line string, cursor uint32) []pro
 			Kind:          &kind,
 		},
 	}
-}
-
-func (v UmaskValue) FetchCompletions(value string, cursor common.CursorPosition) []protocol.CompletionItem {
-	return v.DeprecatedFetchCompletions(
-		value,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			value,
-			0,
-		),
-	)
 }
 
 func (v UmaskValue) DeprecatedFetchHoverInfo(line string, cursor uint32) []string {

--- a/server/handlers/fstab/analyzer/analyzer_test.go
+++ b/server/handlers/fstab/analyzer/analyzer_test.go
@@ -1,0 +1,19 @@
+package analyzer
+
+import (
+	testutils_test "config-lsp/handlers/fstab/test_utils"
+	"testing"
+)
+
+func TestSambaExample(t *testing.T) {
+	// Example from https://askubuntu.com/a/313389/1090198
+	document := testutils_test.DocumentFromInput(t, `
+//192.168.0.5/storage /media/myname/TK-Public/ cifs guest,uid=myuser,iocharset=utf8,file_mode=0777,dir_mode=0777,noperm 0 0
+`)
+
+	diagnostics := Analyze(document)
+
+	if len(diagnostics) != 0 {
+		t.Fatalf("Expected 0 diagnostics, got %d", len(diagnostics))
+	}
+}

--- a/server/handlers/fstab/analyzer/values_test.go
+++ b/server/handlers/fstab/analyzer/values_test.go
@@ -59,3 +59,35 @@ LABEL=test /mnt/test btrfs subvolid=1 0 0
 		t.Fatalf("Expected diagnostic, got %d", len(ctx.diagnostics))
 	}
 }
+
+func TestValidZFSArbitraryPropertyExample(t *testing.T) {
+	document := testutils_test.DocumentFromInput(t, `
+LABEL=test /mnt/test zfs my_arbitrary_user:property=1 0 0
+`)
+
+	ctx := &analyzerContext{
+		document: document,
+	}
+
+	analyzeValuesAreValid(ctx)
+
+	if len(ctx.diagnostics) != 0 {
+		t.Fatalf("Expected no diagnostics, got %d", len(ctx.diagnostics))
+	}
+}
+
+func TestInvalidBtrfsArbitraryPropertyExample(t *testing.T) {
+	document := testutils_test.DocumentFromInput(t, `
+LABEL=test /mnt/test btrfs my_arbitrary_user:property=1 0 0
+`)
+
+	ctx := &analyzerContext{
+		document: document,
+	}
+
+	analyzeValuesAreValid(ctx)
+
+	if len(ctx.diagnostics) == 0 {
+		t.Fatalf("Expected diagnostic, got %d", len(ctx.diagnostics))
+	}
+}

--- a/server/handlers/fstab/fields/mountoptions.go
+++ b/server/handlers/fstab/fields/mountoptions.go
@@ -486,4 +486,8 @@ var MountOptionsMapField = map[string]optionField{
 		Enums:      commondocumentation.BcacheFSDocumentationEnums,
 		Assignable: commondocumentation.BcacheFSDocumentationAssignable,
 	},
+	"cifs": {
+		Enums:      commondocumentation.CifsDocumentationEnums,
+		Assignable: commondocumentation.CifsDocumentationAssignable,
+	},
 }

--- a/server/handlers/fstab/fields/mountoptions.go
+++ b/server/handlers/fstab/fields/mountoptions.go
@@ -490,4 +490,8 @@ var MountOptionsMapField = map[string]optionField{
 		Enums:      commondocumentation.CifsDocumentationEnums,
 		Assignable: commondocumentation.CifsDocumentationAssignable,
 	},
+	"zfs": {
+		Enums:      commondocumentation.ZfsDocumentationEnums,
+		Assignable: commondocumentation.ZfsDocumentationAssignable,
+	},
 }

--- a/server/handlers/fstab/fields/spec.go
+++ b/server/handlers/fstab/fields/spec.go
@@ -13,12 +13,12 @@ var LabelField = docvalues.RegexValue{
 	Regex: *regexp.MustCompile(`\S+`),
 }
 
+var sambaShareField = docvalues.RegexValue{
+	// Match even a trailing slash and later show a diagnostic
+	Regex: *regexp.MustCompile(`^//[^/]+?/.+$`),
+}
 var SpecField = docvalues.OrValue{
 	Values: []docvalues.DeprecatedValue{
-		docvalues.PathValue{
-			IsOptional:   false,
-			RequiredType: docvalues.PathTypeFile,
-		},
 		docvalues.KeyEnumAssignmentValue{
 			Separator:       "=",
 			ValueIsOptional: false,
@@ -28,6 +28,11 @@ var SpecField = docvalues.OrValue{
 				docvalues.CreateEnumString("LABEL"):     LabelField,
 				docvalues.CreateEnumString("PARTLABEL"): LabelField,
 			},
+		},
+		sambaShareField,
+		docvalues.PathValue{
+			IsOptional:   false,
+			RequiredType: docvalues.PathTypeFile,
 		},
 	},
 }

--- a/server/handlers/fstab/handlers/completions.go
+++ b/server/handlers/fstab/handlers/completions.go
@@ -111,5 +111,5 @@ func getFieldSafely(field *ast.FstabField, cursor common.CursorPosition) (string
 		return "", 0
 	}
 
-	return field.Value.Raw, cursor.ShiftHorizontal(-field.Start.Character)
+	return field.Value.Raw, cursor.ShiftHorizontal(-int(field.Start.Character))
 }

--- a/server/handlers/fstab/handlers/completions.go
+++ b/server/handlers/fstab/handlers/completions.go
@@ -21,21 +21,21 @@ func GetCompletion(
 	case ast.FstabFieldSpec:
 		value, cursor := getFieldSafely(entry.Fields.Spec, cursor)
 
-		return fields.SpecField.DeprecatedFetchCompletions(
+		return fields.SpecField.FetchCompletions(
 			value,
 			cursor,
 		), nil
 	case ast.FstabFieldMountPoint:
 		value, cursor := getFieldSafely(entry.Fields.MountPoint, cursor)
 
-		return fields.MountPointField.DeprecatedFetchCompletions(
+		return fields.MountPointField.FetchCompletions(
 			value,
 			cursor,
 		), nil
 	case ast.FstabFieldFileSystemType:
 		value, cursor := getFieldSafely(entry.Fields.FilesystemType, cursor)
 
-		return fields.FileSystemTypeField.DeprecatedFetchCompletions(
+		return fields.FileSystemTypeField.FetchCompletions(
 			value,
 			cursor,
 		), nil
@@ -47,7 +47,7 @@ func GetCompletion(
 		optionsValue := entry.FetchMountOptionsField(false)
 
 		if optionsValue != nil {
-			for _, completion := range optionsValue.DeprecatedFetchCompletions(line, cursor) {
+			for _, completion := range optionsValue.FetchCompletions(line, cursor) {
 				var documentation string
 
 				switch completion.Documentation.(type) {
@@ -66,13 +66,13 @@ func GetCompletion(
 		}
 
 		// Add defaults
-		completions = append(completions, fields.DefaultMountOptionsField.DeprecatedFetchCompletions(line, cursor)...)
+		completions = append(completions, fields.DefaultMountOptionsField.FetchCompletions(line, cursor)...)
 
 		return completions, nil
 	case ast.FstabFieldFreq:
 		value, cursor := getFieldSafely(entry.Fields.Freq, cursor)
 
-		return fields.FreqField.DeprecatedFetchCompletions(
+		return fields.FreqField.FetchCompletions(
 			value,
 			cursor,
 		), nil
@@ -81,12 +81,12 @@ func GetCompletion(
 
 		if entry.Fields.FilesystemType != nil &&
 			utils.KeyExists(fields.FsckOneDisabledFilesystems, strings.ToLower(entry.Fields.FilesystemType.Value.Value)) {
-			return fields.FsckFieldWhenDisabledFilesystems.DeprecatedFetchCompletions(
+			return fields.FsckFieldWhenDisabledFilesystems.FetchCompletions(
 				value,
 				cursor,
 			), nil
 		} else {
-			return fields.FsckField.DeprecatedFetchCompletions(
+			return fields.FsckField.FetchCompletions(
 				value,
 				cursor,
 			), nil
@@ -98,7 +98,7 @@ func GetCompletion(
 
 // Safely get value and new cursor position
 // If field is nil, return empty string and 0
-func getFieldSafely(field *ast.FstabField, cursor common.CursorPosition) (string, uint32) {
+func getFieldSafely(field *ast.FstabField, cursor common.CursorPosition) (string, common.CursorPosition) {
 	if field == nil {
 		return "", 0
 	}
@@ -111,5 +111,5 @@ func getFieldSafely(field *ast.FstabField, cursor common.CursorPosition) (string
 		return "", 0
 	}
 
-	return field.Value.Raw, common.CursorToCharacterIndex(uint32(cursor) - field.Start.Character)
+	return field.Value.Raw, cursor.ShiftHorizontal(-field.Start.Character)
 }

--- a/server/handlers/fstab/lsp/text-document-completion.go
+++ b/server/handlers/fstab/lsp/text-document-completion.go
@@ -19,9 +19,9 @@ func TextDocumentCompletion(context *glsp.Context, params *protocol.CompletionPa
 
 	if !found {
 		// Empty line, return spec completions
-		return fstabdocumentation.SpecField.DeprecatedFetchCompletions(
+		return fstabdocumentation.SpecField.FetchCompletions(
 			"",
-			params.Position.Character,
+			0,
 		), nil
 	}
 

--- a/server/handlers/ssh_config/fields/fields.go
+++ b/server/handlers/ssh_config/fields/fields.go
@@ -795,7 +795,17 @@ rsa-sha2-512,rsa-sha2-256
 		Value: docvalues.KeyValueAssignmentValue{
 			Separator:       " ",
 			ValueIsOptional: true,
-			Key:             docvalues.DataAmountValue{},
+			Key:             &docvalues.DataAmountValue{
+				AllowedUnits: map[rune]struct{}{
+					'K': {},
+					'M': {},
+					'G': {},
+				},
+				AllowDecimal: false,
+				AllowByteSuffix: false,
+				Base: docvalues.DataAmountValueBase1024,
+				Validator: docvalues.CreateDARangeValidator("1G", "4G", docvalues.DataAmountValueBase1024),
+			},
 			Value:           docvalues.TimeFormatValue{},
 		},
 	},

--- a/server/handlers/ssh_config/fields/fields.go
+++ b/server/handlers/ssh_config/fields/fields.go
@@ -795,18 +795,18 @@ rsa-sha2-512,rsa-sha2-256
 		Value: docvalues.KeyValueAssignmentValue{
 			Separator:       " ",
 			ValueIsOptional: true,
-			Key:             &docvalues.DataAmountValue{
+			Key: &docvalues.DataAmountValue{
 				AllowedUnits: map[rune]struct{}{
 					'K': {},
 					'M': {},
 					'G': {},
 				},
-				AllowDecimal: false,
+				AllowDecimal:    false,
 				AllowByteSuffix: false,
-				Base: docvalues.DataAmountValueBase1024,
-				Validator: docvalues.CreateDARangeValidator("1G", "4G", docvalues.DataAmountValueBase1024),
+				Base:            docvalues.DataAmountValueBase1024,
+				Validator:       docvalues.CreateDARangeValidator("1G", "4G", docvalues.DataAmountValueBase1024),
 			},
-			Value:           docvalues.TimeFormatValue{},
+			Value: docvalues.TimeFormatValue{},
 		},
 	},
 	"remotecommand": {

--- a/server/handlers/ssh_config/fields/fields.go
+++ b/server/handlers/ssh_config/fields/fields.go
@@ -795,7 +795,7 @@ rsa-sha2-512,rsa-sha2-256
 		Value: docvalues.KeyValueAssignmentValue{
 			Separator:       " ",
 			ValueIsOptional: true,
-			Key: &docvalues.DataAmountValue{
+			Key: docvalues.DataAmountValue{
 				AllowedUnits: map[rune]struct{}{
 					'K': {},
 					'M': {},

--- a/server/handlers/ssh_config/handlers/completions.go
+++ b/server/handlers/ssh_config/handlers/completions.go
@@ -92,7 +92,7 @@ func GetOptionCompletions(
 	}
 
 	if entry.OptionValue == nil {
-		return option.DeprecatedFetchCompletions("", 0)
+		return option.FetchCompletions("", 0)
 	}
 
 	// token completions
@@ -101,13 +101,9 @@ func GetOptionCompletions(
 	// Hello wo|rld
 	lineValue := entry.OptionValue.Value.Raw
 	// NEW: docvalues index
-	completions = append(completions, option.DeprecatedFetchCompletions(
+	completions = append(completions, option.FetchCompletions(
 		lineValue,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			lineValue,
-			entry.OptionValue.Start.Character,
-		),
+		cursor.ShiftHorizontal(-entry.OptionValue.Start.Character),
 	)...)
 
 	return completions

--- a/server/handlers/ssh_config/handlers/completions.go
+++ b/server/handlers/ssh_config/handlers/completions.go
@@ -103,7 +103,7 @@ func GetOptionCompletions(
 	// NEW: docvalues index
 	completions = append(completions, option.FetchCompletions(
 		lineValue,
-		cursor.ShiftHorizontal(-entry.OptionValue.Start.Character),
+		cursor.ShiftHorizontal(-int(entry.OptionValue.Start.Character)),
 	)...)
 
 	return completions

--- a/server/handlers/ssh_config/handlers/completions_match.go
+++ b/server/handlers/ssh_config/handlers/completions_match.go
@@ -108,7 +108,7 @@ func getMatchValueCompletions(
 
 	if value != nil {
 		line = value.Value.Raw
-		relativeCursor = cursor.ShiftHorizontal(-value.Start.Character)
+		relativeCursor = cursor.ShiftHorizontal(-int(value.Start.Character))
 	} else {
 		line = ""
 		relativeCursor = 0

--- a/server/handlers/ssh_config/handlers/completions_match.go
+++ b/server/handlers/ssh_config/handlers/completions_match.go
@@ -104,15 +104,11 @@ func getMatchValueCompletions(
 	value := entry.GetValueAtPosition(cursor)
 
 	var line string
-	var relativeCursor uint32
+	var relativeCursor common.CursorPosition
 
 	if value != nil {
 		line = value.Value.Raw
-		relativeCursor = common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			line,
-			value.Start.Character,
-		)
+		relativeCursor = cursor.ShiftHorizontal(-value.Start.Character)
 	} else {
 		line = ""
 		relativeCursor = 0
@@ -120,19 +116,19 @@ func getMatchValueCompletions(
 
 	switch entry.Criteria.Type {
 	case matchparser.MatchCriteriaTypeExec:
-		return fields.MatchExecField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchExecField.FetchCompletions(line, relativeCursor)
 	case matchparser.MatchCriteriaTypeLocalNetwork:
-		return fields.MatchLocalNetworkField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchLocalNetworkField.FetchCompletions(line, relativeCursor)
 	case matchparser.MatchCriteriaTypeHost:
-		return fields.MatchHostField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchHostField.FetchCompletions(line, relativeCursor)
 	case matchparser.MatchCriteriaTypeOriginalHost:
-		return fields.MatchOriginalHostField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchOriginalHostField.FetchCompletions(line, relativeCursor)
 	case matchparser.MatchCriteriaTypeTagged:
-		return fields.MatchTypeTaggedField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchTypeTaggedField.FetchCompletions(line, relativeCursor)
 	case matchparser.MatchCriteriaTypeUser:
-		return fields.MatchUserField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchUserField.FetchCompletions(line, relativeCursor)
 	case matchparser.MatchCriteriaTypeLocalUser:
-		return fields.MatchTypeLocalUserField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchTypeLocalUserField.FetchCompletions(line, relativeCursor)
 	}
 
 	return nil

--- a/server/handlers/ssh_config/handlers/hover.go
+++ b/server/handlers/ssh_config/handlers/hover.go
@@ -45,7 +45,7 @@ func GetHoverInfoForOption(
 
 	if option.OptionValue != nil && option.OptionValue.ContainsPosition(index) {
 		line := option.OptionValue.Value.Raw
-		contents := docValue.DeprecatedFetchHoverInfo(
+		contents := docValue.Value.DeprecatedFetchHoverInfo(
 			line,
 			uint32(option.OptionValue.Start.GetRelativeIndexPosition(index)),
 		)

--- a/server/handlers/sshd_config/fields/fields.go
+++ b/server/handlers/sshd_config/fields/fields.go
@@ -851,18 +851,18 @@ Only a subset of keywords may be used on the lines following a Match keyword. Av
 		Value: docvalues.KeyValueAssignmentValue{
 			Separator:       " ",
 			ValueIsOptional: true,
-			Key:             &docvalues.DataAmountValue{
+			Key: &docvalues.DataAmountValue{
 				AllowedUnits: map[rune]struct{}{
 					'K': {},
 					'M': {},
 					'G': {},
 				},
-				AllowDecimal: false,
+				AllowDecimal:    false,
 				AllowByteSuffix: false,
-				Base: docvalues.DataAmountValueBase1024,
-				Validator: docvalues.CreateDARangeValidator("1G", "4G", docvalues.DataAmountValueBase1024),
+				Base:            docvalues.DataAmountValueBase1024,
+				Validator:       docvalues.CreateDARangeValidator("1G", "4G", docvalues.DataAmountValueBase1024),
 			},
-			Value:           docvalues.TimeFormatValue{},
+			Value: docvalues.TimeFormatValue{},
 		},
 	},
 	"requiredrsasize": {

--- a/server/handlers/sshd_config/fields/fields.go
+++ b/server/handlers/sshd_config/fields/fields.go
@@ -851,7 +851,7 @@ Only a subset of keywords may be used on the lines following a Match keyword. Av
 		Value: docvalues.KeyValueAssignmentValue{
 			Separator:       " ",
 			ValueIsOptional: true,
-			Key: &docvalues.DataAmountValue{
+			Key: docvalues.DataAmountValue{
 				AllowedUnits: map[rune]struct{}{
 					'K': {},
 					'M': {},

--- a/server/handlers/sshd_config/fields/fields.go
+++ b/server/handlers/sshd_config/fields/fields.go
@@ -851,7 +851,17 @@ Only a subset of keywords may be used on the lines following a Match keyword. Av
 		Value: docvalues.KeyValueAssignmentValue{
 			Separator:       " ",
 			ValueIsOptional: true,
-			Key:             docvalues.DataAmountValue{},
+			Key:             &docvalues.DataAmountValue{
+				AllowedUnits: map[rune]struct{}{
+					'K': {},
+					'M': {},
+					'G': {},
+				},
+				AllowDecimal: false,
+				AllowByteSuffix: false,
+				Base: docvalues.DataAmountValueBase1024,
+				Validator: docvalues.CreateDARangeValidator("1G", "4G", docvalues.DataAmountValueBase1024),
+			},
 			Value:           docvalues.TimeFormatValue{},
 		},
 	},

--- a/server/handlers/sshd_config/handlers/completions.go
+++ b/server/handlers/sshd_config/handlers/completions.go
@@ -105,7 +105,7 @@ func GetOptionCompletions(
 		completions,
 		option.FetchCompletions(
 			line,
-			cursor.ShiftHorizontal(-entry.OptionValue.Start.Character),
+			cursor.ShiftHorizontal(-int(entry.OptionValue.Start.Character)),
 		)...,
 	)
 

--- a/server/handlers/sshd_config/handlers/completions.go
+++ b/server/handlers/sshd_config/handlers/completions.go
@@ -92,7 +92,7 @@ func GetOptionCompletions(
 	}
 
 	if entry.OptionValue == nil {
-		return option.DeprecatedFetchCompletions("", 0)
+		return option.FetchCompletions("", 0)
 	}
 
 	// token completions
@@ -101,14 +101,13 @@ func GetOptionCompletions(
 	// Hello wo|rld
 	line := entry.OptionValue.Value.Raw
 	// NEW: docvalues index
-	completions = append(completions, option.DeprecatedFetchCompletions(
-		line,
-		common.DeprecatedImprovedCursorToIndex(
-			cursor,
+	completions = append(
+		completions,
+		option.FetchCompletions(
 			line,
-			entry.OptionValue.Start.Character,
-		),
-	)...)
+			cursor.ShiftHorizontal(-entry.OptionValue.Start.Character),
+		)...,
+	)
 
 	return completions
 }

--- a/server/handlers/sshd_config/handlers/completions_match.go
+++ b/server/handlers/sshd_config/handlers/completions_match.go
@@ -85,7 +85,7 @@ func getMatchValueCompletions(
 
 	if value != nil {
 		line = value.Value.Raw
-		relativeCursor = cursor.ShiftHorizontal(-value.Start.Character)
+		relativeCursor = cursor.ShiftHorizontal(-int(value.Start.Character))
 	} else {
 		line = ""
 		relativeCursor = 0

--- a/server/handlers/sshd_config/handlers/completions_match.go
+++ b/server/handlers/sshd_config/handlers/completions_match.go
@@ -81,15 +81,11 @@ func getMatchValueCompletions(
 	value := entry.GetValueAtPosition(cursor)
 
 	var line string
-	var relativeCursor uint32
+	var relativeCursor common.CursorPosition
 
 	if value != nil {
 		line = value.Value.Raw
-		relativeCursor = common.DeprecatedImprovedCursorToIndex(
-			cursor,
-			line,
-			value.Start.Character,
-		)
+		relativeCursor = cursor.ShiftHorizontal(-value.Start.Character)
 	} else {
 		line = ""
 		relativeCursor = 0
@@ -97,19 +93,19 @@ func getMatchValueCompletions(
 
 	switch entry.Criteria.Type {
 	case matchparser.MatchCriteriaTypeUser:
-		return fields.MatchUserField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchUserField.FetchCompletions(line, relativeCursor)
 	case matchparser.MatchCriteriaTypeGroup:
-		return fields.MatchGroupField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchGroupField.FetchCompletions(line, relativeCursor)
 	case matchparser.MatchCriteriaTypeHost:
-		return fields.MatchHostField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchHostField.FetchCompletions(line, relativeCursor)
 	case matchparser.MatchCriteriaTypeAddress:
-		return fields.MatchAddressField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchAddressField.FetchCompletions(line, relativeCursor)
 	case matchparser.MatchCriteriaTypeLocalAddress:
-		return fields.MatchLocalAddressField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchLocalAddressField.FetchCompletions(line, relativeCursor)
 	case matchparser.MatchCriteriaTypeLocalPort:
-		return fields.MatchLocalPortField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchLocalPortField.FetchCompletions(line, relativeCursor)
 	case matchparser.MatchCriteriaTypeRDomain:
-		return fields.MatchRDomainField.DeprecatedFetchCompletions(line, relativeCursor)
+		return fields.MatchRDomainField.FetchCompletions(line, relativeCursor)
 	}
 
 	return nil

--- a/server/handlers/sshd_config/handlers/hover.go
+++ b/server/handlers/sshd_config/handlers/hover.go
@@ -56,8 +56,11 @@ func GetHoverInfoForOption(
 	}
 
 	if option.OptionValue != nil && option.OptionValue.ContainsPosition(index) {
-		line := option.OptionValue.Value.Raw
-		contents := docValue.DeprecatedFetchHoverInfo(
+		line := option.OptionValue.Value.Value
+		// `DocumentationValue` only shows the documentation for `DeprecatedFetchHoverInfo`,
+		// since the cursor here is now at the value, we use the `Value`'s method instead to
+		// get the proper info.
+		contents := docValue.Value.DeprecatedFetchHoverInfo(
 			line,
 			uint32(option.OptionValue.Start.GetRelativeIndexPosition(index)),
 		)

--- a/server/handlers/wireguard/analyzer/properties.go
+++ b/server/handlers/wireguard/analyzer/properties.go
@@ -3,10 +3,10 @@ package analyzer
 import (
 	"config-lsp/common"
 	docvalues "config-lsp/doc-values"
-	"config-lsp/handlers/wireguard/ast"
 	"config-lsp/handlers/wireguard/diagnostics"
 	"config-lsp/handlers/wireguard/fields"
 	"config-lsp/handlers/wireguard/indexes"
+	"config-lsp/parsers/ini"
 	"fmt"
 
 	protocol "github.com/tliron/glsp/protocol_3_16"
@@ -20,11 +20,11 @@ func analyzeProperties(
 
 		// Whether to check if the property is allowed in the section
 		checkAllowedProperty := true
-		existingProperties := make(map[fields.NormalizedName]*ast.WGProperty)
+		existingProperties := make(map[fields.NormalizedName]*ini.Property)
 
 		it := section.Properties.Iterator()
 		for it.Next() {
-			property := it.Value().(*ast.WGProperty)
+			property := it.Value().(*ini.Property)
 			normalizedPropertyName := fields.CreateNormalizedName(property.Key.Name)
 
 			if property.Key.Name == "" {

--- a/server/handlers/wireguard/ast/wireguard.go
+++ b/server/handlers/wireguard/ast/wireguard.go
@@ -2,45 +2,26 @@ package ast
 
 import (
 	"config-lsp/common"
-	"github.com/emirpasic/gods/maps/treemap"
+	"config-lsp/parsers/ini"
 )
 
-type WGPropertyKey struct {
-	common.LocationRange
-	Name string
-}
-
-type WGPropertyValue struct {
-	common.LocationRange
-	Value string
-}
-
-type WGPropertySeparator struct {
-	common.LocationRange
-}
-
-type WGProperty struct {
-	common.LocationRange
-	RawValue  string
-	Key       WGPropertyKey
-	Separator *WGPropertySeparator
-	Value     *WGPropertyValue
-}
-
-type WGHeader struct {
-	common.LocationRange
-	Name string
-}
-
-type WGSection struct {
-	common.LocationRange
-	Header WGHeader
-	// [uint32]*WGProperty: line number -> *WGProperty
-	Properties *treemap.Map
-}
-
 type WGConfig struct {
-	Sections []*WGSection
-	// Used to identify where not to show diagnostics
-	CommentLines map[uint32]struct{}
+	*ini.Config
+}
+
+// NewWGConfig creates a new WireGuard configuration
+func NewWGConfig() *WGConfig {
+	return &WGConfig{
+		Config: ini.NewConfig(),
+	}
+}
+
+// Reset the configuration
+func (c *WGConfig) Clear() {
+	c.Config.Clear()
+}
+
+// Parse a WireGuard configuration string
+func (c *WGConfig) Parse(input string) []common.LSPError {
+	return c.Config.Parse(input)
 }

--- a/server/handlers/wireguard/fields/fields_formatted.go
+++ b/server/handlers/wireguard/fields/fields_formatted.go
@@ -10,7 +10,7 @@ var AllOptionsFormatted = map[NormalizedName]string{
 	"mtu":        "MTU",
 	"preup":      "PreUp",
 	"postup":     "PostUp",
-	"predown":    "Predown",
+	"predown":    "PreDown",
 	"postdown":   "PostDown",
 	"fwmark":     "FwMark",
 

--- a/server/handlers/wireguard/handlers/code-actions.go
+++ b/server/handlers/wireguard/handlers/code-actions.go
@@ -12,6 +12,7 @@ const (
 	CodeActionGeneratePrivateKey   CodeActionName = "generatePrivateKey"
 	CodeActionGeneratePresharedKey CodeActionName = "generatePresharedKey"
 	CodeActionCreatePeer           CodeActionName = "createPeer"
+	CodeActionGeneratePostDown     CodeActionName = "generatePostDown"
 )
 
 type CodeAction interface {

--- a/server/handlers/wireguard/handlers/code-actions_generate-postdown.go
+++ b/server/handlers/wireguard/handlers/code-actions_generate-postdown.go
@@ -1,0 +1,101 @@
+package handlers
+
+import (
+	"config-lsp/handlers/wireguard"
+	"config-lsp/utils"
+	"errors"
+	"strings"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+type CodeActionGeneratePostdownKeyArgs struct {
+	URI protocol.DocumentUri
+}
+
+func CodeActionGeneratePostdownArgsFromArguments(arguments map[string]any) CodeActionGeneratePostdownKeyArgs {
+	return CodeActionGeneratePostdownKeyArgs{
+		URI: arguments["URI"].(protocol.DocumentUri),
+	}
+}
+
+func (args CodeActionGeneratePostdownKeyArgs) RunCommand(d *wireguard.WGDocument) (*protocol.ApplyWorkspaceEditParams, error) {
+	if utils.BlockUntilIndexesNotNil(d.Indexes) == false {
+		return nil, errors.New("Indexes are not ready yet")
+	}
+
+	lastUpPropertyKey := utils.FindBiggestKey(d.Indexes.UpProperties)
+	lastUpProperty := d.Indexes.UpProperties[lastUpPropertyKey]
+
+	// TODO: Find out if the user specified multiple PreDown or only one (or maybe don't do this at all)
+
+	rules := findAllIPTableRules(d)
+	invertedRules := generateInvertedRules(rules)
+
+	if len(invertedRules) == 0 {
+		return nil, errors.New("No valid iptables rules found to invert")
+	}
+
+	newRulesString := strings.Join(invertedRules, "; ")
+	newPropertyString := "\nPostDown = " + newRulesString + "\n"
+
+	label := "Generate PostDown with inverted rules"
+	return &protocol.ApplyWorkspaceEditParams{
+		Label: &label,
+		Edit: protocol.WorkspaceEdit{
+			Changes: map[protocol.DocumentUri][]protocol.TextEdit{
+				args.URI: {
+					{
+						Range: protocol.Range{
+							Start: lastUpProperty.Property.Value.ToLSPRange().End,
+							End:   lastUpProperty.Property.Value.ToLSPRange().End,
+						},
+						NewText: newPropertyString,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func findAllIPTableRules(
+	d *wireguard.WGDocument,
+) []string {
+	upRules := make([]string, 0)
+
+	for _, info := range d.Indexes.UpProperties {
+		if info.Property != nil && info.Property.Value != nil {
+			rulesRaw := info.Property.Value.Value
+			rules := strings.Split(rulesRaw, ";")
+
+			upRules = append(upRules, rules...)
+		}
+	}
+
+	return upRules
+}
+
+func generateInvertedRules(rules []string) []string {
+	var postDownRules []string
+
+	for _, rule := range rules {
+		ipTableRule, err := utils.ParseIpTableRule(rule)
+
+		if err != nil {
+			return nil
+		}
+
+		inverted := ipTableRule.InvertAction()
+
+		if inverted.Action != utils.IpTableActionDelete {
+			// We only want to generate actions for common actions
+			return nil
+		}
+
+		ruleStringRaw := inverted.String()
+		ruleString := strings.ReplaceAll(strings.TrimSpace(ruleStringRaw), "  ", " ")
+		postDownRules = append(postDownRules, ruleString)
+	}
+
+	return postDownRules
+}

--- a/server/handlers/wireguard/handlers/completions_body.go
+++ b/server/handlers/wireguard/handlers/completions_body.go
@@ -4,8 +4,8 @@ import (
 	"config-lsp/common"
 	docvalues "config-lsp/doc-values"
 	"config-lsp/handlers/wireguard"
-	"config-lsp/handlers/wireguard/ast"
 	"config-lsp/handlers/wireguard/fields"
+	"config-lsp/parsers/ini"
 	"config-lsp/utils"
 	"maps"
 
@@ -14,8 +14,8 @@ import (
 
 func GetSectionBodyCompletions(
 	d *wireguard.WGDocument,
-	section ast.WGSection,
-	property *ast.WGProperty,
+	section ini.Section,
+	property *ini.Property,
 	params *protocol.CompletionParams,
 ) ([]protocol.CompletionItem, error) {
 	// These are the possible scenarios:
@@ -78,8 +78,8 @@ func GetSectionBodyCompletions(
 
 func getPropertyCompletions(
 	d *wireguard.WGDocument,
-	section ast.WGSection,
-	property *ast.WGProperty,
+	section ini.Section,
+	property *ini.Property,
 	params *protocol.CompletionParams,
 ) ([]protocol.CompletionItem, error) {
 	// These are the possible scenarios:
@@ -111,11 +111,11 @@ func getPropertyCompletions(
 	}
 
 	// Otherwise, suggest value completions
-	return getValueCompletions(section, *property, position), nil
+	return getValueCompletions(section, property, position), nil
 }
 
 func getKeyCompletions(
-	section ast.WGSection,
+	section ini.Section,
 	onlySeparator bool,
 	currentLine uint32,
 ) []protocol.CompletionItem {
@@ -134,13 +134,13 @@ func getKeyCompletions(
 	// Remove existing, non-duplicate options
 	it := section.Properties.Iterator()
 	for it.Next() {
-		property := it.Value().(*ast.WGProperty)
-		normalizedName := fields.CreateNormalizedName(property.Key.Name)
+		iniProperty := it.Value().(*ini.Property)
+		normalizedName := fields.CreateNormalizedName(iniProperty.Key.Name)
 		if _, found := allowedDuplicatedFields[normalizedName]; found {
 			continue
 		}
 
-		if property.Key.Start.Line == currentLine {
+		if iniProperty.Key.Start.Line == currentLine {
 			// The user is currently typing the key, thus we should suggest it
 			continue
 		}
@@ -176,8 +176,8 @@ func getKeyCompletions(
 }
 
 func getValueCompletions(
-	section ast.WGSection,
-	property ast.WGProperty,
+	section ini.Section,
+	property *ini.Property,
 	cursorPosition common.CursorPosition,
 ) []protocol.CompletionItem {
 	// TODO: Normalize section header name

--- a/server/handlers/wireguard/handlers/completions_body.go
+++ b/server/handlers/wireguard/handlers/completions_body.go
@@ -199,7 +199,7 @@ func getValueCompletions(
 	} else {
 		return option.FetchCompletions(
 			property.Value.Value,
-			cursor.ShiftHorizontal(-property.Value.Start.Character),
+			cursor.ShiftHorizontal(-int(property.Value.Start.Character)),
 		)
 	}
 }

--- a/server/handlers/wireguard/handlers/completions_body.go
+++ b/server/handlers/wireguard/handlers/completions_body.go
@@ -178,7 +178,7 @@ func getKeyCompletions(
 func getValueCompletions(
 	section ini.Section,
 	property *ini.Property,
-	cursorPosition common.CursorPosition,
+	cursor common.CursorPosition,
 ) []protocol.CompletionItem {
 	// TODO: Normalize section header name
 	normalizedHeaderName := fields.CreateNormalizedName(section.Header.Name)
@@ -195,15 +195,11 @@ func getValueCompletions(
 	}
 
 	if property.Value == nil {
-		return option.DeprecatedFetchCompletions("", 0)
+		return option.FetchCompletions("", 0)
 	} else {
-		return option.DeprecatedFetchCompletions(
+		return option.FetchCompletions(
 			property.Value.Value,
-			common.DeprecatedImprovedCursorToIndex(
-				cursorPosition,
-				property.Value.Value,
-				property.Value.Start.Character,
-			),
+			cursor.ShiftHorizontal(-property.Value.Start.Character),
 		)
 	}
 }

--- a/server/handlers/wireguard/handlers/fetch-code-actions_create-peer.go
+++ b/server/handlers/wireguard/handlers/fetch-code-actions_create-peer.go
@@ -6,7 +6,7 @@ import (
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
-func GetAddPeerLikeThis(
+func GetAddPeerLikeThisCodeActions(
 	d *wireguard.WGDocument,
 	params *protocol.CodeActionParams,
 ) []protocol.CodeAction {

--- a/server/handlers/wireguard/handlers/fetch-code-actions_generate-postdown.go
+++ b/server/handlers/wireguard/handlers/fetch-code-actions_generate-postdown.go
@@ -13,7 +13,7 @@ func GetGeneratePostDownCodeActions(
 	d *wireguard.WGDocument,
 	params *protocol.CodeActionParams,
 ) []protocol.CodeAction {
-	postDownPropertyNames := map[fields.NormalizedName]struct{}{
+	postPrePropertyNames := map[fields.NormalizedName]struct{}{
 		fields.CreateNormalizedName("PreUp"):  {},
 		fields.CreateNormalizedName("PostUp"): {},
 	}
@@ -35,7 +35,7 @@ func GetGeneratePostDownCodeActions(
 	property := rawProperty.(*ini.Property)
 
 	propertyName := fields.CreateNormalizedName(property.Key.Name)
-	if (utils.KeyExists(postDownPropertyNames, propertyName)) && (property.Value != nil) {
+	if (utils.KeyExists(postPrePropertyNames, propertyName)) && (property.Value != nil) {
 		// Only propose this action if no PostDown is already present
 		_, postDownProperty := section.FindFirstPropertyByName("PostDown")
 

--- a/server/handlers/wireguard/handlers/fetch-code-actions_generate-postdown.go
+++ b/server/handlers/wireguard/handlers/fetch-code-actions_generate-postdown.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"config-lsp/handlers/wireguard"
+	"config-lsp/handlers/wireguard/fields"
+	"config-lsp/parsers/ini"
+	"config-lsp/utils"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+func GetGeneratePostDownCodeActions(
+	d *wireguard.WGDocument,
+	params *protocol.CodeActionParams,
+) []protocol.CodeAction {
+	postDownPropertyNames := map[fields.NormalizedName]struct{}{
+		fields.CreateNormalizedName("PreUp"):  {},
+		fields.CreateNormalizedName("PostUp"): {},
+	}
+
+	line := params.Range.Start.Line
+
+	section := d.Config.FindSectionByLine(line)
+
+	if section == nil {
+		return nil
+	}
+
+	rawProperty, found := section.Properties.Get(line)
+
+	if !found {
+		return nil
+	}
+
+	property := rawProperty.(*ini.Property)
+
+	propertyName := fields.CreateNormalizedName(property.Key.Name)
+	if (utils.KeyExists(postDownPropertyNames, propertyName)) && (property.Value != nil) {
+		// Only propose this action if no PostDown is already present
+		_, postDownProperty := section.FindFirstPropertyByName("PostDown")
+
+		if postDownProperty == nil {
+			commandID := "wireguard." + CodeActionGeneratePostDown
+
+			command := protocol.Command{
+				Title:   "Generate PostDown with inverted rules",
+				Command: string(commandID),
+				Arguments: []any{
+					CodeActionGeneratePostdownKeyArgs{
+						URI: params.TextDocument.URI,
+					},
+				},
+			}
+
+			return []protocol.CodeAction{
+				{
+					Title:   "Generate PostDown with inverted rules",
+					Command: &command,
+				},
+			}
+		}
+	}
+
+	return nil
+}

--- a/server/handlers/wireguard/handlers/hover.go
+++ b/server/handlers/wireguard/handlers/hover.go
@@ -4,8 +4,8 @@ import (
 	"config-lsp/common"
 	docvalues "config-lsp/doc-values"
 	"config-lsp/handlers/wireguard"
-	"config-lsp/handlers/wireguard/ast"
 	"config-lsp/handlers/wireguard/fields"
+	"config-lsp/parsers/ini"
 	"fmt"
 	"strings"
 
@@ -14,8 +14,8 @@ import (
 
 func GetPropertyHoverInfo(
 	d *wireguard.WGDocument,
-	section ast.WGSection,
-	property ast.WGProperty,
+	section ini.Section,
+	property ini.Property,
 	index common.IndexPosition,
 ) (*protocol.Hover, error) {
 	availableOptions, found := fields.OptionsHeaderMap[fields.CreateNormalizedName(section.Header.Name)]
@@ -53,7 +53,7 @@ func GetPropertyHoverInfo(
 
 func GetSectionHoverInfo(
 	d *wireguard.WGDocument,
-	section ast.WGSection,
+	section ini.Section,
 ) (*protocol.Hover, error) {
 	var docValue *docvalues.EnumString = nil
 

--- a/server/handlers/wireguard/indexes/indexes.go
+++ b/server/handlers/wireguard/indexes/indexes.go
@@ -1,15 +1,17 @@
 package indexes
 
-import "config-lsp/handlers/wireguard/ast"
+import (
+	"config-lsp/parsers/ini"
+)
 
 type WGIndexPropertyInfo struct {
-	Section  *ast.WGSection
-	Property *ast.WGProperty
+	Section  *ini.Section
+	Property *ini.Property
 }
 
 type WGIndexes struct {
-	// map of: section name -> *WGSection
-	SectionsByName map[string][]*ast.WGSection
+	// map of: section name -> *ini.Section
+	SectionsByName map[string][]*ini.Section
 
 	// map of: line number -> *WGIndexPropertyInfo
 	UnknownProperties map[uint32]WGIndexPropertyInfo

--- a/server/handlers/wireguard/indexes/indexes.go
+++ b/server/handlers/wireguard/indexes/indexes.go
@@ -13,6 +13,9 @@ type WGIndexes struct {
 	// map of: section name -> *ini.Section
 	SectionsByName map[string][]*ini.Section
 
-	// map of: line number -> *WGIndexPropertyInfo
+	// map of: line number -> WGIndexPropertyInfo
 	UnknownProperties map[uint32]WGIndexPropertyInfo
+
+	// map of: line number -> WGIndexPropertyInfo (PreUp / PostUp properties)
+	UpProperties map[uint32]WGIndexPropertyInfo
 }

--- a/server/handlers/wireguard/indexes/indexes_handlers.go
+++ b/server/handlers/wireguard/indexes/indexes_handlers.go
@@ -3,14 +3,21 @@ package indexes
 import (
 	"config-lsp/common"
 	"config-lsp/handlers/wireguard/ast"
+	"config-lsp/handlers/wireguard/fields"
 	"config-lsp/parsers/ini"
 )
+
+var upPropertyNames = map[fields.NormalizedName]struct{}{
+	fields.CreateNormalizedName("PreUp"):  {},
+	fields.CreateNormalizedName("PostUp"): {},
+}
 
 func CreateIndexes(config *ast.WGConfig) (*WGIndexes, []common.LSPError) {
 	errs := make([]common.LSPError, 0)
 	indexes := &WGIndexes{
 		SectionsByName:    make(map[string][]*ini.Section),
 		UnknownProperties: make(map[uint32]WGIndexPropertyInfo),
+		UpProperties:      make(map[uint32]WGIndexPropertyInfo),
 	}
 
 	// Use the WGSections from the config
@@ -21,6 +28,20 @@ func CreateIndexes(config *ast.WGConfig) (*WGIndexes, []common.LSPError) {
 			indexes.SectionsByName[sectionName],
 			section,
 		)
+
+		it := section.Properties.Iterator()
+		for it.Next() {
+			lineNumber := it.Key().(uint32)
+			property := it.Value().(*ini.Property)
+			normalizedName := fields.CreateNormalizedName(property.Key.Name)
+
+			if _, found := upPropertyNames[normalizedName]; found {
+				indexes.UpProperties[lineNumber] = WGIndexPropertyInfo{
+					Section:  section,
+					Property: property,
+				}
+			}
+		}
 	}
 
 	return indexes, errs

--- a/server/handlers/wireguard/indexes/indexes_handlers.go
+++ b/server/handlers/wireguard/indexes/indexes_handlers.go
@@ -3,18 +3,22 @@ package indexes
 import (
 	"config-lsp/common"
 	"config-lsp/handlers/wireguard/ast"
+	"config-lsp/parsers/ini"
 )
 
 func CreateIndexes(config *ast.WGConfig) (*WGIndexes, []common.LSPError) {
 	errs := make([]common.LSPError, 0)
 	indexes := &WGIndexes{
-		SectionsByName:    make(map[string][]*ast.WGSection),
+		SectionsByName:    make(map[string][]*ini.Section),
 		UnknownProperties: make(map[uint32]WGIndexPropertyInfo),
 	}
 
+	// Use the WGSections from the config
 	for _, section := range config.Sections {
-		indexes.SectionsByName[section.Header.Name] = append(
-			indexes.SectionsByName[section.Header.Name],
+		sectionName := section.Header.Name
+
+		indexes.SectionsByName[sectionName] = append(
+			indexes.SectionsByName[sectionName],
 			section,
 		)
 	}

--- a/server/handlers/wireguard/indexes/indexes_test.go
+++ b/server/handlers/wireguard/indexes/indexes_test.go
@@ -1,0 +1,43 @@
+package indexes
+
+import (
+	"config-lsp/handlers/wireguard/ast"
+	"testing"
+)
+
+func TestIndexesUpProperties(t *testing.T) {
+	content := `
+[Interface]
+PrivateKey = abc
+PreUp = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT
+`
+
+	config := ast.NewWGConfig()
+	errs := config.Parse(content)
+
+	if len(errs) > 0 {
+		t.Fatalf("Failed to parse config: %v", errs)
+	}
+
+	indexes, errs := CreateIndexes(config)
+
+	if len(errs) > 0 {
+		t.Fatalf("Unexpected errors while creating indexes: %v", errs)
+	}
+
+	if len(indexes.UpProperties) != 1 {
+		t.Errorf("Expected 1 UpProperty, got %d", len(indexes.UpProperties))
+	}
+
+	if indexes.UpProperties[3].Section.Header.Name != "Interface" {
+		t.Errorf("Expected UpProperty section name 'Interface', got '%s'", indexes.UpProperties[0].Section.Header.Name)
+	}
+
+	if indexes.UpProperties[3].Property.Key.Name != "PreUp" {
+		t.Errorf("Expected UpProperty key name 'PreUp', got '%s'", indexes.UpProperties[0].Property.Key.Name)
+	}
+
+	if indexes.UpProperties[3].Property.Value.Value != "iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT" {
+		t.Errorf("Expected UpProperty value; %v", indexes.UpProperties[0].Property.Value.Value)
+	}
+}

--- a/server/handlers/wireguard/indexes/indexes_test.go
+++ b/server/handlers/wireguard/indexes/indexes_test.go
@@ -30,14 +30,14 @@ PreUp = iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT
 	}
 
 	if indexes.UpProperties[3].Section.Header.Name != "Interface" {
-		t.Errorf("Expected UpProperty section name 'Interface', got '%s'", indexes.UpProperties[0].Section.Header.Name)
+		t.Errorf("Expected UpProperty section name 'Interface', got '%s'", indexes.UpProperties[3].Section.Header.Name)
 	}
 
 	if indexes.UpProperties[3].Property.Key.Name != "PreUp" {
-		t.Errorf("Expected UpProperty key name 'PreUp', got '%s'", indexes.UpProperties[0].Property.Key.Name)
+		t.Errorf("Expected UpProperty key name 'PreUp', got '%s'", indexes.UpProperties[3].Property.Key.Name)
 	}
 
 	if indexes.UpProperties[3].Property.Value.Value != "iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT" {
-		t.Errorf("Expected UpProperty value; %v", indexes.UpProperties[0].Property.Value.Value)
+		t.Errorf("Expected UpProperty value; %v", indexes.UpProperties[3].Property.Value.Value)
 	}
 }

--- a/server/handlers/wireguard/lsp/text-document-code-action.go
+++ b/server/handlers/wireguard/lsp/text-document-code-action.go
@@ -15,8 +15,9 @@ func TextDocumentCodeAction(context *glsp.Context, params *protocol.CodeActionPa
 
 	actions = append(actions, handlers.GetKeyGenerationCodeActions(d, params)...)
 	actions = append(actions, handlers.GetKeepaliveCodeActions(d, params)...)
-	actions = append(actions, handlers.GetAddPeerLikeThis(d, params)...)
+	actions = append(actions, handlers.GetAddPeerLikeThisCodeActions(d, params)...)
 	actions = append(actions, handlers.GetPropertyKeywordTypoFixes(d, params)...)
+	actions = append(actions, handlers.GetGeneratePostDownCodeActions(d, params)...)
 
 	if len(actions) > 0 {
 		return actions, nil

--- a/server/handlers/wireguard/lsp/workspace-execute-command.go
+++ b/server/handlers/wireguard/lsp/workspace-execute-command.go
@@ -31,6 +31,11 @@ func WorkspaceExecuteCommand(context *glsp.Context, params *protocol.ExecuteComm
 		d := wireguard.DocumentParserMap[args.URI]
 
 		return args.RunCommand(d)
+	case string(handlers.CodeActionGeneratePostDown):
+		args := handlers.CodeActionGeneratePostdownArgsFromArguments(params.Arguments[0].(map[string]any))
+
+		d := wireguard.DocumentParserMap[args.URI]
+		return args.RunCommand(d)
 	}
 
 	return nil, nil

--- a/server/nvim-lsp-debug.lua
+++ b/server/nvim-lsp-debug.lua
@@ -1,5 +1,0 @@
-vim.lsp.start {
-    name = "config-lsp",
-    cmd = { "./result/bin/config-lsp" },
-    root_dir = vim.fn.getcwd(),
-};

--- a/server/nvim-lsp-debug.lua
+++ b/server/nvim-lsp-debug.lua
@@ -1,0 +1,5 @@
+vim.lsp.start {
+    name = "config-lsp",
+    cmd = { "./result/bin/config-lsp" },
+    root_dir = vim.fn.getcwd(),
+};

--- a/server/parsers/index.go
+++ b/server/parsers/index.go
@@ -1,0 +1,1 @@
+package parsers

--- a/server/parsers/ini/ast.go
+++ b/server/parsers/ini/ast.go
@@ -1,0 +1,54 @@
+package ini
+
+import (
+	"config-lsp/common"
+	"github.com/emirpasic/gods/maps/treemap"
+)
+
+// PropertyKey represents a key in an INI property
+type PropertyKey struct {
+	common.LocationRange
+	Name string
+}
+
+// PropertyValue represents a value in an INI property
+type PropertyValue struct {
+	common.LocationRange
+	Value string
+}
+
+// PropertySeparator represents the separator in an INI property
+type PropertySeparator struct {
+	common.LocationRange
+}
+
+// Property represents a key-value pair in an INI document
+type Property struct {
+	common.LocationRange
+	RawValue string
+
+	Key       PropertyKey
+	Separator *PropertySeparator
+	Value     *PropertyValue
+}
+
+// Header represents a section header in an INI document
+type Header struct {
+	common.LocationRange
+	Name string
+}
+
+// Section represents a section in an INI document
+type Section struct {
+	common.LocationRange
+	Header Header
+	// [uint32]*Property: line number -> *Property
+	Properties *treemap.Map
+}
+
+// Config represents a complete INI document
+type Config struct {
+	Sections []*Section
+	// Used to identify where not to show diagnostics
+	CommentLines map[uint32]struct{}
+}

--- a/server/parsers/ini/fields.go
+++ b/server/parsers/ini/fields.go
@@ -1,14 +1,15 @@
-package ast
+package ini
 
 import (
 	"slices"
 )
 
-func (c *WGConfig) FindSectionByLine(line uint32) *WGSection {
+// Find the section containing the specified line
+func (c *Config) FindSectionByLine(line uint32) *Section {
 	index, found := slices.BinarySearchFunc(
 		c.Sections,
 		line,
-		func(current *WGSection, target uint32) int {
+		func(current *Section, target uint32) int {
 			if target < current.Start.Line {
 				return 1
 			}
@@ -28,7 +29,8 @@ func (c *WGConfig) FindSectionByLine(line uint32) *WGSection {
 	return c.Sections[index]
 }
 
-func (c *WGConfig) FindPropertyByLine(line uint32) *WGProperty {
+// Find a property at the specified line
+func (c *Config) FindPropertyByLine(line uint32) *Property {
 	section := c.FindSectionByLine(line)
 
 	if section == nil {
@@ -36,17 +38,18 @@ func (c *WGConfig) FindPropertyByLine(line uint32) *WGProperty {
 	}
 
 	if property, found := section.Properties.Get(line); found {
-		return property.(*WGProperty)
+		return property.(*Property)
 	}
 
 	return nil
 }
 
-func (s *WGSection) FindFirstPropertyByName(name string) (uint32, *WGProperty) {
+// Find the first property with the given name in a section
+func (s *Section) FindFirstPropertyByName(name string) (uint32, *Property) {
 	it := s.Properties.Iterator()
 	for it.Next() {
 		line := it.Key().(uint32)
-		property := it.Value().(*WGProperty)
+		property := it.Value().(*Property)
 		if property.Key.Name == name {
 			return line, property
 		}
@@ -55,12 +58,13 @@ func (s *WGSection) FindFirstPropertyByName(name string) (uint32, *WGProperty) {
 	return 0, nil
 }
 
-func (s *WGSection) GetLastProperty() *WGProperty {
+// Find the last property in a section
+func (s *Section) GetLastProperty() *Property {
 	if s.Properties.Size() == 0 {
 		return nil
 	}
 
 	lastLine, _ := s.Properties.Max()
 	lastProperty, _ := s.Properties.Get(lastLine)
-	return lastProperty.(*WGProperty)
+	return lastProperty.(*Property)
 }

--- a/server/parsers/ini/parser.go
+++ b/server/parsers/ini/parser.go
@@ -28,7 +28,7 @@ func (c *Config) Clear() {
 var commentPattern = regexp.MustCompile(`^\s*([;#])`)
 var emptyPattern = regexp.MustCompile(`^\s*$`)
 var headerPattern = regexp.MustCompile(`^\s*\[(\w+)?]?`)
-var linePattern = regexp.MustCompile(`^\s*(?P<key>.+?)\s*(?P<separator>=)\s*(?P<value>\S.*?)?\s*(?:[;#].*)?\s*$`)
+var linePattern = regexp.MustCompile(`^\s*(?P<key>.+?)\s*(?P<separator>=)\s*(?P<value>\S.*?)?\s*(?: [;#].*)?\s*$`)
 
 // Parse parses an INI string and returns any errors encountered
 func (c *Config) Parse(input string) []common.LSPError {

--- a/server/parsers/ini/parser.go
+++ b/server/parsers/ini/parser.go
@@ -1,4 +1,4 @@
-package ast
+package ini
 
 import (
 	"config-lsp/common"
@@ -11,15 +11,17 @@ import (
 	gods "github.com/emirpasic/gods/utils"
 )
 
-func NewWGConfig() *WGConfig {
-	config := &WGConfig{}
+// NewConfig creates a new empty INI configuration
+func NewConfig() *Config {
+	config := &Config{}
 	config.Clear()
 
 	return config
 }
 
-func (c *WGConfig) Clear() {
-	c.Sections = make([]*WGSection, 0, 2)
+// Clear resets the configuration
+func (c *Config) Clear() {
+	c.Sections = make([]*Section, 0, 2)
 	c.CommentLines = make(map[uint32]struct{})
 }
 
@@ -28,11 +30,12 @@ var emptyPattern = regexp.MustCompile(`^\s*$`)
 var headerPattern = regexp.MustCompile(`^\s*\[(\w+)?]?`)
 var linePattern = regexp.MustCompile(`^\s*(?P<key>.+?)\s*(?P<separator>=)\s*(?P<value>\S.*?)?\s*(?:[;#].*)?\s*$`)
 
-func (c *WGConfig) Parse(input string) []common.LSPError {
+// Parse parses an INI string and returns any errors encountered
+func (c *Config) Parse(input string) []common.LSPError {
 	errors := make([]common.LSPError, 0)
 	lines := utils.SplitIntoLines(input)
 
-	var currentSection *WGSection
+	var currentSection *Section
 
 	for rawLineNumber, line := range lines {
 		lineNumber := uint32(rawLineNumber)
@@ -59,7 +62,7 @@ func (c *WGConfig) Parse(input string) []common.LSPError {
 		if headerPattern.MatchString(line) {
 			name := headerPattern.FindStringSubmatch(line)[1]
 
-			currentSection = &WGSection{
+			currentSection = &Section{
 				LocationRange: common.LocationRange{
 					Start: common.Location{
 						Line:      lineNumber,
@@ -70,7 +73,7 @@ func (c *WGConfig) Parse(input string) []common.LSPError {
 						Character: uint32(len(line)) + 1,
 					},
 				},
-				Header: WGHeader{
+				Header: Header{
 					LocationRange: common.LocationRange{
 						Start: common.Location{
 							Line:      lineNumber,
@@ -122,8 +125,8 @@ func (c *WGConfig) Parse(input string) []common.LSPError {
 			// Incomplete property
 			indexes := utils.GetTrimIndex(line)
 
-			newProperty := &WGProperty{
-				Key: WGPropertyKey{
+			newProperty := &Property{
+				Key: PropertyKey{
 					LocationRange: common.LocationRange{
 						Start: common.Location{
 							Line:      lineNumber,
@@ -166,7 +169,7 @@ func (c *WGConfig) Parse(input string) []common.LSPError {
 			// Construct key
 			keyStart := uint32(indexes[2])
 			keyEnd := uint32(indexes[3])
-			key := WGPropertyKey{
+			key := PropertyKey{
 				LocationRange: common.LocationRange{
 					Start: common.Location{
 						Line:      lineNumber,
@@ -183,7 +186,7 @@ func (c *WGConfig) Parse(input string) []common.LSPError {
 			// Construct separator
 			separatorStart := uint32(indexes[4])
 			separatorEnd := uint32(indexes[5])
-			separator := WGPropertySeparator{
+			separator := PropertySeparator{
 				LocationRange: common.LocationRange{
 					Start: common.Location{
 						Line:      lineNumber,
@@ -197,7 +200,7 @@ func (c *WGConfig) Parse(input string) []common.LSPError {
 			}
 
 			// Construct value
-			var value *WGPropertyValue
+			var value *PropertyValue
 			propertyEnd := uint32(len(line))
 
 			if indexes[6] != -1 && indexes[7] != -1 {
@@ -206,7 +209,7 @@ func (c *WGConfig) Parse(input string) []common.LSPError {
 				valueEnd := uint32(indexes[7])
 				propertyEnd = valueEnd
 
-				value = &WGPropertyValue{
+				value = &PropertyValue{
 					LocationRange: common.LocationRange{
 						Start: common.Location{
 							Line:      lineNumber,
@@ -222,7 +225,7 @@ func (c *WGConfig) Parse(input string) []common.LSPError {
 			}
 
 			// And lastly, add the property
-			newProperty := &WGProperty{
+			newProperty := &Property{
 				LocationRange: common.LocationRange{
 					Start: common.Location{
 						Line:      lineNumber,

--- a/server/parsers/ini/parser_test.go
+++ b/server/parsers/ini/parser_test.go
@@ -13,6 +13,7 @@ func TestParserWorks(t *testing.T) {
 [Interface]
 PrivateKey = 1234567890 # Some comment
 Address = 10.0.0.1
+PostUp = iptables -I FORWARD -i wg0 -j ACCEPT; iptables -I INPUT -i wg0 -j ACCEPT
 
 
 
@@ -30,12 +31,12 @@ PublicKey = 1234567890
 		t.Fatalf("Parse: Expected no errors, but got %v", errors)
 	}
 
-	if !(utils.KeyExists(config.CommentLines, 0) && utils.KeyExists(config.CommentLines, 12)) {
-		t.Errorf("Parse: Expected comments to be present on lines 0 and 12")
+	if !(utils.KeyExists(config.CommentLines, 0) && utils.KeyExists(config.CommentLines, 13)) {
+		t.Errorf("Parse: Expected comments to be present on lines 0 and 13")
 	}
 
-	if !(config.Sections[0].Start.Line == 3 && config.Sections[0].End.Line == 8) {
-		t.Errorf("Parse: Expected section 0 to be present on lines 3 and 6, but it is: %v", config.Sections[0].End)
+	if !(config.Sections[0].Start.Line == 3 && config.Sections[0].End.Line == 9) {
+		t.Errorf("Parse: Expected section 0 to be present on lines 3 and 9, but it is: %v", config.Sections[0].End)
 	}
 
 	if !(config.Sections[0].Start.Character == 0 && config.Sections[0].End.Character == 0) {
@@ -58,9 +59,15 @@ PublicKey = 1234567890
 		t.Errorf("Parse: Expected property line 5 to be correct")
 	}
 
-	rawTenthProperty, _ := config.Sections[1].Properties.Get(uint32(10))
+	rawTenthProperty, _ := config.Sections[1].Properties.Get(uint32(11))
 	tenthProperty := rawTenthProperty.(*Property)
 	if !(tenthProperty.Key.Name == "PublicKey" && tenthProperty.Value.Value == "1234567890") {
-		t.Errorf("Parse: Expected property line 10 to be correct")
+		t.Errorf("Parse: Expected property line 11 to be correct")
+	}
+
+	rawPostUpProperty, _ := config.Sections[0].Properties.Get(uint32(6))
+	postUpProperty := rawPostUpProperty.(*Property)
+	if !(postUpProperty.Key.Name == "PostUp" && postUpProperty.Value.Value == "iptables -I FORWARD -i wg0 -j ACCEPT; iptables -I INPUT -i wg0 -j ACCEPT") {
+		t.Errorf("Parse: Expected PostUp property to be correct; %v; %v", postUpProperty, postUpProperty.Value.Value)
 	}
 }

--- a/server/parsers/ini/parser_test.go
+++ b/server/parsers/ini/parser_test.go
@@ -1,13 +1,11 @@
-package ast
+package ini
 
 import (
 	"config-lsp/utils"
 	"testing"
 )
 
-func TestExample1Works(
-	t *testing.T,
-) {
+func TestParserWorks(t *testing.T) {
 	sample := utils.Dedent(`
 # A comment at the very top
 
@@ -24,7 +22,7 @@ PublicKey = 1234567890
 ; I'm a comment
 `)
 
-	config := NewWGConfig()
+	config := NewConfig()
 
 	errors := config.Parse(sample)
 
@@ -49,19 +47,19 @@ PublicKey = 1234567890
 	}
 
 	rawFourthProperty, _ := config.Sections[0].Properties.Get(uint32(4))
-	fourthProperty := rawFourthProperty.(*WGProperty)
+	fourthProperty := rawFourthProperty.(*Property)
 	if !(fourthProperty.Key.Name == "PrivateKey" && fourthProperty.Value.Value == "1234567890") {
 		t.Errorf("Parse: Expected property line 4 to be correct")
 	}
 
 	rawFifthProperty, _ := config.Sections[0].Properties.Get(uint32(5))
-	fifthProperty := rawFifthProperty.(*WGProperty)
+	fifthProperty := rawFifthProperty.(*Property)
 	if !(fifthProperty.Key.Name == "Address" && fifthProperty.Value.Value == "10.0.0.1") {
 		t.Errorf("Parse: Expected property line 5 to be correct")
 	}
 
 	rawTenthProperty, _ := config.Sections[1].Properties.Get(uint32(10))
-	tenthProperty := rawTenthProperty.(*WGProperty)
+	tenthProperty := rawTenthProperty.(*Property)
 	if !(tenthProperty.Key.Name == "PublicKey" && tenthProperty.Value.Value == "1234567890") {
 		t.Errorf("Parse: Expected property line 10 to be correct")
 	}

--- a/server/utils/common.go
+++ b/server/utils/common.go
@@ -73,17 +73,17 @@ func CalculateNumericValueToByte(
 	case 'k':
 		byteAmount = uint64(amount * base)
 	case 'm':
-		byteAmount = uint64(amount * base*base)
+		byteAmount = uint64(amount * base * base)
 	case 'g':
-		byteAmount = uint64(amount * base*base*base)
+		byteAmount = uint64(amount * base * base * base)
 	case 't':
-		byteAmount = uint64(amount * base*base*base*base)
+		byteAmount = uint64(amount * base * base * base * base)
 	case 'e':
-		byteAmount = uint64(amount * base*base*base*base*base)
+		byteAmount = uint64(amount * base * base * base * base * base)
 	case 'p':
-		byteAmount = uint64(amount * base*base*base*base*base*base)
+		byteAmount = uint64(amount * base * base * base * base * base * base)
 	case 'z':
-		byteAmount = uint64(amount * base*base*base*base*base*base*base)
+		byteAmount = uint64(amount * base * base * base * base * base * base * base)
 	default:
 		byteAmount = uint64(amount)
 	}

--- a/server/utils/common.go
+++ b/server/utils/common.go
@@ -30,3 +30,67 @@ func IsPathFile(path string) bool {
 
 	return true
 }
+
+// Calculate a numeric value from a string and return it as a byte.
+// Supports decimal values.
+// Supported units:
+// - `k` for kilobytes
+// - `m` for megabytes
+// - `g` for gigabytes
+// - `t` for terabytes
+// - `e` for exabytes
+// - `p` for petabytes
+// - `z` for zettabytes
+// Supports bit / Byte suffixes:
+// - `b` for bits
+// - `B` for bytes
+// For bits the value will be rounded down to the nearest byte.
+// base is either 1000 or 1024.
+// Returns an error if the value is invalid or the unit is not supported.
+func CalculateNumericValueToByte(
+	amount float64,
+	unit rune,
+	suffix string,
+	base uint64,
+) (uint64, error) {
+	if base != 1000 && base != 1024 {
+		return 0, errors.New("base must be either 1000 or 1024")
+	}
+
+	if amount < 0 {
+		return 0, errors.New("amount must be greater than or equal to 0")
+	}
+
+	var byteAmount uint64 = 0
+
+	if suffix == "b" {
+		// If the suffix is 'b', we treat it as bits.
+		// 1 byte = 8 bits, so we divide the amount by 8.
+		amount /= 8
+	}
+
+	switch unit {
+	case 'k':
+		byteAmount = uint64(amount) * base
+	case 'm':
+		byteAmount = uint64(amount) * base*base
+	case 'g':
+		byteAmount = uint64(amount) * base*base*base
+	case 't':
+		byteAmount = uint64(amount) * base*base*base*base
+	case 'e':
+		byteAmount = uint64(amount) * base*base*base*base*base
+	case 'p':
+		byteAmount = uint64(amount) * base*base*base*base*base*base
+	case 'z':
+		byteAmount = uint64(amount) * base*base*base*base*base*base*base
+	default:
+		byteAmount = uint64(amount)
+	}
+
+	if byteAmount < 0 {
+		return 0, errors.New("calculated byte amount is negative")
+	}
+
+	return byteAmount, nil
+}

--- a/server/utils/common.go
+++ b/server/utils/common.go
@@ -51,7 +51,7 @@ func CalculateNumericValueToByte(
 	amount float64,
 	unit rune,
 	suffix string,
-	base uint64,
+	base float64,
 ) (uint64, error) {
 	if base != 1000 && base != 1024 {
 		return 0, errors.New("base must be either 1000 or 1024")
@@ -71,19 +71,19 @@ func CalculateNumericValueToByte(
 
 	switch unit {
 	case 'k':
-		byteAmount = uint64(amount) * base
+		byteAmount = uint64(amount * base)
 	case 'm':
-		byteAmount = uint64(amount) * base*base
+		byteAmount = uint64(amount * base*base)
 	case 'g':
-		byteAmount = uint64(amount) * base*base*base
+		byteAmount = uint64(amount * base*base*base)
 	case 't':
-		byteAmount = uint64(amount) * base*base*base*base
+		byteAmount = uint64(amount * base*base*base*base)
 	case 'e':
-		byteAmount = uint64(amount) * base*base*base*base*base
+		byteAmount = uint64(amount * base*base*base*base*base)
 	case 'p':
-		byteAmount = uint64(amount) * base*base*base*base*base*base
+		byteAmount = uint64(amount * base*base*base*base*base*base)
 	case 'z':
-		byteAmount = uint64(amount) * base*base*base*base*base*base*base
+		byteAmount = uint64(amount * base*base*base*base*base*base*base)
 	default:
 		byteAmount = uint64(amount)
 	}

--- a/server/utils/common.go
+++ b/server/utils/common.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"os"
+	"unicode"
 )
 
 func DoesPathExist(path string) bool {
@@ -69,7 +70,7 @@ func CalculateNumericValueToByte(
 		amount /= 8
 	}
 
-	switch unit {
+	switch unicode.ToLower(unit) {
 	case 'k':
 		byteAmount = uint64(amount * base)
 	case 'm':
@@ -84,8 +85,10 @@ func CalculateNumericValueToByte(
 		byteAmount = uint64(amount * base * base * base * base * base * base)
 	case 'z':
 		byteAmount = uint64(amount * base * base * base * base * base * base * base)
+	case ' ':
+		byteAmount = uint64(amount) // No unit, treat as bytes
 	default:
-		byteAmount = uint64(amount)
+		return 0, errors.New("unsupported unit: " + string(unit))
 	}
 
 	return byteAmount, nil

--- a/server/utils/common.go
+++ b/server/utils/common.go
@@ -88,9 +88,5 @@ func CalculateNumericValueToByte(
 		byteAmount = uint64(amount)
 	}
 
-	if byteAmount < 0 {
-		return 0, errors.New("calculated byte amount is negative")
-	}
-
 	return byteAmount, nil
 }

--- a/server/utils/iptables.go
+++ b/server/utils/iptables.go
@@ -1,0 +1,100 @@
+package utils
+
+import (
+	"errors"
+	"regexp"
+)
+
+type IpTableActionEnum uint8
+
+const (
+	IpTableActionAppend IpTableActionEnum = iota
+	IpTableActionInsert
+	IpTableActionCheck
+	IpTableActionDelete
+)
+
+type IpTableRule struct {
+	Action IpTableActionEnum
+	// Position in the rule list
+	// This is used to make the deletion command as similar to the original rule as possible
+	ActionIndex uint32
+	Command     string
+}
+
+func (i IpTableRule) InvertAction() IpTableRule {
+	actionMap := map[IpTableActionEnum]IpTableActionEnum{
+		IpTableActionAppend: IpTableActionDelete,
+		IpTableActionInsert: IpTableActionDelete,
+		IpTableActionCheck:  IpTableActionDelete,
+		IpTableActionDelete: IpTableActionAppend,
+	}
+
+	return IpTableRule{
+		Action:      actionMap[i.Action],
+		ActionIndex: i.ActionIndex,
+		Command:     i.Command,
+	}
+}
+
+func (i IpTableRule) String() string {
+	actionStr := ""
+
+	switch i.Action {
+	case IpTableActionAppend:
+		actionStr = "-A"
+	case IpTableActionInsert:
+		actionStr = "-I"
+	case IpTableActionCheck:
+		actionStr = "-C"
+	case IpTableActionDelete:
+		actionStr = "-D"
+	}
+
+	ruleRaw := i.Command[:i.ActionIndex] + " " + actionStr + " " + i.Command[i.ActionIndex:]
+
+	// Multiple spaces should be removed by the caller
+	return ruleRaw
+}
+
+var rulePattern = regexp.MustCompile(`\B(-I|-D|-C|-A|--insert|--append|--check|--delete)\b`)
+var actionMap = map[string]IpTableActionEnum{
+	"-I":       IpTableActionInsert,
+	"--insert": IpTableActionInsert,
+	"-D":       IpTableActionDelete,
+	"--delete": IpTableActionDelete,
+	"-C":       IpTableActionCheck,
+	"--check":  IpTableActionCheck,
+	"-A":       IpTableActionAppend,
+	"--append": IpTableActionAppend,
+}
+
+// A very simple parser for iptable rules.
+// Better approach: Use something like antlr or ast to parse the rules.
+func ParseIpTableRule(rule string) (*IpTableRule, error) {
+	matches := rulePattern.FindIndex([]byte(rule))
+
+	if len(matches) != 2 {
+		return nil, errors.New("Invalid iptable rule. Couldn't find action")
+	}
+
+	actionStart := matches[0]
+	actionEnd := matches[1]
+
+	action := rule[actionStart:actionEnd]
+
+	actionEnum, found := actionMap[action]
+
+	if !found {
+		return nil, errors.New("Invalid iptable rule. Unknown action: " + action)
+	}
+
+	// Remove the action from the rule
+	newRule := rule[:actionStart] + rule[actionEnd:]
+
+	return &IpTableRule{
+		Action:      actionEnum,
+		ActionIndex: uint32(actionStart),
+		Command:     newRule,
+	}, nil
+}

--- a/server/utils/iptables_test.go
+++ b/server/utils/iptables_test.go
@@ -1,0 +1,90 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSimpleIPTableRuleParsing(t *testing.T) {
+	rule := `iptables -I FORWARD -i wg0 -j ACCEPT`
+
+	parsedRule, err := ParseIpTableRule(rule)
+
+	if err != nil {
+		t.Fatalf("Failed to parse rule: %v", err)
+	}
+
+	if parsedRule.Action != IpTableActionInsert {
+		t.Errorf("Expected action to be %v, got %v", IpTableActionInsert, parsedRule.Action)
+	}
+
+	if parsedRule.Command != "iptables  FORWARD -i wg0 -j ACCEPT" {
+		t.Errorf("Expected command to be 'iptables  FORWARD -i wg0 -j ACCEPT', got '%s'", parsedRule.Command)
+	}
+
+	if parsedRule.ActionIndex != 9 {
+		t.Errorf("Expected action index to be 9, got %d", parsedRule.ActionIndex)
+	}
+}
+
+func TestSimpleIPTableRule2Parsing(t *testing.T) {
+	rule := `iptables --insert FORWARD -i wg0 -j ACCEPT`
+
+	_, err := ParseIpTableRule(rule)
+
+	if err != nil {
+		t.Fatalf("Failed to parse rule: %v", err)
+	}
+}
+
+func TestInvalidIPTableRuleParsing(t *testing.T) {
+	rule := `iptables -i wg0 -j ACCEPT`
+
+	_, err := ParseIpTableRule(rule)
+
+	if err == nil {
+		t.Fatal("Expected error for invalid rule, but got none")
+	}
+}
+
+// ========== Test negation ==========
+
+func TestSimpleIPTableRuleNegation(t *testing.T) {
+	rule := `iptables -I FORWARD -i wg0 -j ACCEPT`
+
+	parsedRule, err := ParseIpTableRule(rule)
+
+	if err != nil {
+		t.Fatalf("Failed to parse rule: %v", err)
+	}
+
+	negatedRule := strings.ReplaceAll(
+		strings.TrimSpace(
+			parsedRule.InvertAction().String(),
+		), "  ", " ",
+	)
+
+	if negatedRule != `iptables -D FORWARD -i wg0 -j ACCEPT` {
+		t.Errorf("Expected negated rule to be 'iptables -D FORWARD -i wg0 -j ACCEPT', got '%s'", negatedRule)
+	}
+}
+
+func TestComplexIPTableRuleNegation(t *testing.T) {
+	rule := `iptables -I FORWARD -i wg0 -o eth0 -p tcp --dport 80 -j ACCEPT`
+
+	parsedRule, err := ParseIpTableRule(rule)
+
+	if err != nil {
+		t.Fatalf("Failed to parse rule: %v", err)
+	}
+
+	negatedRule := strings.ReplaceAll(
+		strings.TrimSpace(
+			parsedRule.InvertAction().String(),
+		), "  ", " ",
+	)
+
+	if negatedRule != `iptables -D FORWARD -i wg0 -o eth0 -p tcp --dport 80 -j ACCEPT` {
+		t.Errorf("Expected negated rule to be 'iptables -D FORWARD -i wg0 -o eth0 -p tcp --dport 80 -j ACCEPT', got '%s'", negatedRule)
+	}
+}

--- a/server/utils/lsp.go
+++ b/server/utils/lsp.go
@@ -1,0 +1,26 @@
+package utils
+
+import protocol "github.com/tliron/glsp/protocol_3_16"
+
+// If you have a list of completions but they don't start with the same word
+// (word defined as separated by spaces), then the LSP client will not
+// show the completions. This function adds the `substr` to the beginning
+// of each completion item.
+func AddSubstrToCompletionItems(
+	completions []protocol.CompletionItem,
+	substr string,
+) []protocol.CompletionItem {
+	return Map(
+		completions,
+		func(item protocol.CompletionItem) protocol.CompletionItem {
+			newItem := item
+			newItem.Label = substr + newItem.Label
+
+			if newItem.InsertText != nil {
+				*newItem.InsertText = substr + *newItem.InsertText
+			}
+
+			return newItem
+		},
+	)
+}

--- a/server/utils/quotes.go
+++ b/server/utils/quotes.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"cmp"
 	"slices"
 )
 
@@ -22,7 +21,14 @@ func (q quoteRanges) GetQuoteForIndex(index int) *quoteRange {
 		q,
 		index,
 		func(current quoteRange, target int) int {
-			return cmp.Compare(target, current[0])
+			if target < current[0] {
+				return -1
+			}
+			if target > current[1] {
+				return 1
+			}
+
+			return 0
 		},
 	)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive CIFS and ZFS mount options documentation and validation metadata.
  * Enhanced data amount value parsing, validation, and context-aware completion suggestions.
  * Introduced WireGuard code actions to generate "PostDown" commands by inverting iptables rules.
  * Strengthened SSH/SSHD "rekeylimit" option validation with explicit unit and range constraints.
  * Extended INI parser and AST for improved configuration parsing and handling.
  * Added new cursor-based completion APIs across multiple configuration value types.
  * Added support for Samba share specifications in mount point fields.
  * Added ZFS user property validation in mount options.
  * Added utility to prepend substrings to completion items for better LSP client compatibility.

* **Bug Fixes**
  * Fixed WireGuard option capitalization ("PreDown").
  * Improved validation for optional values and duplicate detection in key-enum assignments.
  * Corrected cursor index calculations to avoid off-by-one errors.

* **Refactor**
  * Modernized completion fetching APIs to use a unified cursor type across config handlers.
  * Migrated WireGuard configuration handling from custom AST to generic INI parser structures.
  * Updated WireGuard code to use INI parser types and removed deprecated methods.
  * Replaced deprecated cursor index calculations with cursor position adjustments.
  * Refactored mount options validation to handle ZFS arbitrary user properties.
  * Unified WireGuard hover, completion, and indexing logic to use INI parser types.

* **Tests**
  * Added unit tests covering data amount parsing, key-enum assignments, iptables rule parsing, array value parsing, and WireGuard indexing.
  * Added WireGuard analyzer test for Samba mount example.
  * Added tests for ZFS user property validation in mount options.

* **Chores**
  * Updated documentation and comments for clarity and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->